### PR TITLE
Renaming 'Power' Converters

### DIFF
--- a/src/main/java/tech/units/indriya/AbstractConverter.java
+++ b/src/main/java/tech/units/indriya/AbstractConverter.java
@@ -54,7 +54,8 @@ import tech.uom.lib.common.function.Converter;
  *
  * @author <a href="mailto:jean-marie@dautelle.com">Jean-Marie Dautelle</a>
  * @author <a href="mailto:units@catmedia.us">Werner Keil</a>
- * @version 1.5, April 19, 2018
+ * @author Andi Huber
+ * @version 1.6, April 26, 2018
  * @since 1.0
  */
 public abstract class AbstractConverter
@@ -98,9 +99,56 @@ public abstract class AbstractConverter
 
 	@Override
 	public abstract int hashCode();
-
+	
+	// -- TO-STRING - CONTRACT AND INTERFACE IMPLEMENTATION (FINAL)
+	
+	/**
+	 * Non-API
+	 * <p>
+	 * Returns a String describing the transformation that is represented by this converter. 
+	 * Contributes to converter's {@code toString} method. If null or empty
+	 * {@code toString} output becomes simplified.
+	 * </p>
+	 * @return 
+	 */
+	protected abstract String transformationLiteral();
+	
 	@Override
-	public abstract AbstractConverter inverse();
+	public final String toString() {
+		String converterName = getClass().getSimpleName();
+		// omit trailing 'Converter'
+		if(converterName.endsWith("Converter")) {
+			converterName = converterName.substring(0, converterName.length()-"Converter".length());
+		}
+		if(isIdentity()) {
+			return String.format("%s(IDENTITY)", converterName);
+		}
+		final String transformationLiteral = transformationLiteral();
+		if(transformationLiteral==null || transformationLiteral.length()==0) {
+			return String.format("%s", converterName);
+		}
+		return String.format("%s(%s)", converterName, transformationLiteral);
+	}
+
+	// -- INVERSION - CONTRACT AND INTERFACE IMPLEMENTATION (FINAL)
+	
+	/**
+	 * Non-API
+	 * <p>
+	 * Returns an AbstractConverter that represents the inverse transformation of this converter,
+	 * for cases where the transformation is not the identity transformation.
+	 * </p>  
+	 * @return 
+	 */
+	protected abstract AbstractConverter inverseWhenNotIdentity();
+	
+	@Override
+	public final AbstractConverter inverse() {
+		if(isIdentity()) {
+			return this;
+		}
+		return inverseWhenNotIdentity();
+	}
 	
 	// -- COMPOSITION CONTRACTS (TO BE IMPLEMENTED BY SUB-CLASSES)
 
@@ -230,11 +278,6 @@ public abstract class AbstractConverter
 		}
 
 		@Override
-		public Identity inverse() {
-			return this;
-		}
-
-		@Override
 		public double convertWhenNotIdentity(double value) {
 			throw new IllegalStateException("code was reached, that is expected unreachable");
 		}
@@ -251,7 +294,7 @@ public abstract class AbstractConverter
 
 		@Override
 		public boolean equals(Object cvtr) {
-			return (cvtr instanceof Identity); //TODO [ahuber] unless we have a clear spec what equals is, this is questionable
+			return (cvtr instanceof Identity); 
 		}
 
 		@Override
@@ -280,6 +323,16 @@ public abstract class AbstractConverter
 		@Override
 		protected AbstractConverter simpleCompose(AbstractConverter that) {
 			throw new IllegalStateException("code was reached, that is expected unreachable");
+		}
+
+		@Override
+		protected AbstractConverter inverseWhenNotIdentity() {
+			throw new IllegalStateException("code was reached, that is expected unreachable");
+		}
+		
+		@Override
+		protected String transformationLiteral() {
+			return null;
 		}
 		
 	}
@@ -350,7 +403,7 @@ public abstract class AbstractConverter
 		}
 
 		@Override
-		public Pair inverse() {
+		public Pair inverseWhenNotIdentity() {
 			return new Pair(right.inverse(), left.inverse());
 		}
 
@@ -430,12 +483,13 @@ public abstract class AbstractConverter
 		}
 		
 		@Override
-		public String toString() {
-			return String.format("AbstractConverter.Pair[%s]",
-					getConversionSteps().stream()
-					.map(UnitConverter::toString)
-					.collect(Collectors.joining(", ")) );
+		protected String transformationLiteral() {
+			return String.format("%s",
+				getConversionSteps().stream()
+				.map(UnitConverter::toString)
+				.collect(Collectors.joining(" ○ ")) );
 		}
+		
 
 		@Override
 		protected boolean isSimpleCompositionWith(AbstractConverter that) {

--- a/src/main/java/tech/units/indriya/AbstractConverter.java
+++ b/src/main/java/tech/units/indriya/AbstractConverter.java
@@ -43,7 +43,7 @@ import java.util.stream.Collectors;
 import javax.measure.Prefix;
 import javax.measure.UnitConverter;
 
-import tech.units.indriya.function.PowerConverter;
+import tech.units.indriya.function.PowersOfIntConverter;
 import tech.units.indriya.function.UnitComparator;
 import tech.uom.lib.common.function.Converter;
 
@@ -90,7 +90,7 @@ public abstract class AbstractConverter
 	 *            the prefix for the factor.
 	 */
 	public static UnitConverter of(Prefix prefix) {
-		return PowerConverter.of(prefix);
+		return PowersOfIntConverter.of(prefix);
 	}
 
 	@Override

--- a/src/main/java/tech/units/indriya/AbstractUnit.java
+++ b/src/main/java/tech/units/indriya/AbstractUnit.java
@@ -51,8 +51,8 @@ import tech.units.indriya.function.AddConverter;
 import tech.units.indriya.function.ExpConverter;
 import tech.units.indriya.function.LogConverter;
 import tech.units.indriya.function.MultiplyConverter;
-import tech.units.indriya.function.PiPowerConverter;
-import tech.units.indriya.function.PowerConverter;
+import tech.units.indriya.function.PowersOfPiConverter;
+import tech.units.indriya.function.PowersOfIntConverter;
 import tech.units.indriya.function.RationalConverter;
 import tech.units.indriya.quantity.QuantityDimension;
 import tech.units.indriya.spi.DimensionalModel;
@@ -567,7 +567,7 @@ public abstract class AbstractUnit<Q extends Quantity<Q>> implements ComparableU
 	
 	@Override
 	public Unit<Q> prefix(Prefix prefix) {
-		return this.transform(PowerConverter.of(prefix));
+		return this.transform(PowersOfIntConverter.of(prefix));
 	}
 
 	/**
@@ -656,10 +656,10 @@ public abstract class AbstractUnit<Q extends Quantity<Q>> implements ComparableU
 		
 		private final static Map<Class<?>, Integer> normalFormOrder = new HashMap<>(6);
 		static {
-			normalFormOrder.put(PowerConverter.class, 1); 
+			normalFormOrder.put(PowersOfIntConverter.class, 1); 
 			normalFormOrder.put(RationalConverter.class, 2); 
 			normalFormOrder.put(MultiplyConverter.class, 3);
-			normalFormOrder.put(PiPowerConverter.class, 4); 
+			normalFormOrder.put(PowersOfPiConverter.class, 4); 
 			normalFormOrder.put(AddConverter.class, 5);
 			normalFormOrder.put(LogConverter.class, 6); 
 			normalFormOrder.put(ExpConverter.class, 7);
@@ -722,8 +722,8 @@ public abstract class AbstractUnit<Q extends Quantity<Q>> implements ComparableU
 		
 		private static boolean isNormalFormOrderWhenCommutative(AbstractConverter a, AbstractConverter b) {
 			if(a.getClass().equals(b.getClass())) {
-				if(a instanceof PowerConverter) {
-					return  ((PowerConverter)a).getBase() <= ((PowerConverter)b).getBase();
+				if(a instanceof PowersOfIntConverter) {
+					return  ((PowersOfIntConverter)a).getBase() <= ((PowersOfIntConverter)b).getBase();
 				}
 				if(a instanceof LogConverter) {
 					return  ((LogConverter)a).getBase() <= ((LogConverter)b).getBase();

--- a/src/main/java/tech/units/indriya/Calculus.java
+++ b/src/main/java/tech/units/indriya/Calculus.java
@@ -99,9 +99,68 @@ public final class Calculus {
 			return BigInteger.valueOf(number.longValue());
 		}
 		logger.fine(()->String.format(
-				"WARNING: possibly loosing precision, when converting from Number type '%s' to double.",
+				"WARNING: possibly loosing precision, when converting from Number type '%s' to long.",
 				number.getClass().getName()));
 		return BigInteger.valueOf(number.longValue());
+	}
+
+	/**
+	 * Returns the absolute value of {@code number}
+	 * @param number
+	 * @return 
+	 */
+	public static Number abs(Number number) {
+		Objects.requireNonNull(number, "number can not be null");
+		if(number instanceof BigInteger) {
+			return ((BigInteger) number).abs();
+		}
+		if(number instanceof BigDecimal) {
+			return ((BigDecimal) number).abs();
+		}
+		if(number instanceof Double) {
+			return Math.abs((double)number);
+		}
+		if(number instanceof Long) {
+			return Math.abs((long)number);
+		}
+		if(number instanceof Integer) {
+			return Math.abs((int)number);
+		}
+		if(number instanceof Short) {
+			return Math.abs((short)number);
+		}
+		if(number instanceof Byte) {
+			return Math.abs((byte)number);
+		}
+		logger.fine(()->String.format(
+				"WARNING: possibly loosing precision, when converting from Number type '%s' to double.",
+				number.getClass().getName()));
+		return Math.abs(number.doubleValue());
+	}
+
+	/**
+	 * 
+	 * @param number
+	 * @return
+	 */
+	public static boolean isLessThanOne(Number number) {
+		Objects.requireNonNull(number, "number can not be null");
+		if(number instanceof BigInteger) {
+			return ((BigInteger) number).compareTo(BigInteger.ONE) == -1;
+		}
+		if(number instanceof BigDecimal) {
+			return ((BigDecimal) number).compareTo(BigDecimal.ONE) == -1;
+		}
+		if(number instanceof Double) {
+			return ((double)number) < 1.0;
+		}
+		if(number instanceof Long || number instanceof Integer || number instanceof Short || number instanceof Byte) {
+			return number.longValue() < 1L;
+		}
+		logger.fine(()->String.format(
+				"WARNING: possibly loosing precision, when converting from Number type '%s' to double.",
+				number.getClass().getName()));
+		return number.doubleValue() < 1.0;
 	}
 
 

--- a/src/main/java/tech/units/indriya/Calculus.java
+++ b/src/main/java/tech/units/indriya/Calculus.java
@@ -137,6 +137,40 @@ public final class Calculus {
 				number.getClass().getName()));
 		return Math.abs(number.doubleValue());
 	}
+	
+	/**
+	 * Returns the absolute value of {@code number}
+	 * @param number
+	 * @return 
+	 */
+	public static Number negate(Number number) {
+		Objects.requireNonNull(number, "number can not be null");
+		if(number instanceof BigInteger) {
+			return ((BigInteger) number).negate();
+		}
+		if(number instanceof BigDecimal) {
+			return ((BigDecimal) number).negate();
+		}
+		if(number instanceof Double) {
+			return -((double)number);
+		}
+		if(number instanceof Long) {
+			return -((long)number);
+		}
+		if(number instanceof Integer) {
+			return -((int)number);
+		}
+		if(number instanceof Short) {
+			return -((short)number);
+		}
+		if(number instanceof Byte) {
+			return -((byte)number);
+		}
+		logger.fine(()->String.format(
+				"WARNING: possibly loosing precision, when converting from Number type '%s' to double.",
+				number.getClass().getName()));
+		return -(number.doubleValue());
+	}
 
 	/**
 	 * 

--- a/src/main/java/tech/units/indriya/Calculus.java
+++ b/src/main/java/tech/units/indriya/Calculus.java
@@ -139,9 +139,9 @@ public final class Calculus {
 	}
 	
 	/**
-	 * Returns the absolute value of {@code number}
+	 * Returns the negated value of {@code number}
 	 * @param number
-	 * @return 
+	 * @return -number
 	 */
 	public static Number negate(Number number) {
 		Objects.requireNonNull(number, "number can not be null");

--- a/src/main/java/tech/units/indriya/format/ConverterFormatter.java
+++ b/src/main/java/tech/units/indriya/format/ConverterFormatter.java
@@ -65,7 +65,7 @@ class ConverterFormatter {
    * @return the operator precedence of the given UnitConverter
    */
   static int formatConverter(UnitConverter converter, boolean continued, int unitPrecedence, StringBuilder buffer, SymbolMap symbolMap) {
-    final Prefix prefix = symbolMap.getPrefix((PowerConverter) converter);
+    final Prefix prefix = symbolMap.getPrefix((PowersOfIntConverter) converter);
     if ((prefix != null) && (unitPrecedence == EBNFHelper.NOOP_PRECEDENCE)) {
       return noopPrecedence(buffer, symbolMap, prefix);
     } else if (converter instanceof AddConverter) {
@@ -78,8 +78,8 @@ class ConverterFormatter {
       return productPrecedence((MultiplyConverter) converter, continued, unitPrecedence, buffer);
     } else if (converter instanceof RationalConverter) {
         return productPrecedence((RationalConverter) converter, continued, unitPrecedence, buffer);
-    } else if (converter instanceof PowerConverter) {
-        return productPrecedence((PowerConverter) converter, continued, unitPrecedence, buffer);
+    } else if (converter instanceof PowersOfIntConverter) {
+        return productPrecedence((PowersOfIntConverter) converter, continued, unitPrecedence, buffer);
     } else if (converter instanceof AbstractConverter.Pair) {
       AbstractConverter.Pair compound = (AbstractConverter.Pair) converter;
       if (compound.getLeft() == AbstractConverter.IDENTITY) {
@@ -109,12 +109,12 @@ class ConverterFormatter {
     }
   }
 
-  private static int productPrecedence(PowerConverter converter, boolean continued, int unitPrecedence, StringBuilder buffer) {
+  private static int productPrecedence(PowersOfIntConverter converter, boolean continued, int unitPrecedence, StringBuilder buffer) {
     if (unitPrecedence < EBNFHelper.PRODUCT_PRECEDENCE) {
       buffer.insert(0, '(');
       buffer.append(')');
     }
-    PowerConverter powerConverter = converter;
+    PowersOfIntConverter powerConverter = converter;
     
     if(!powerConverter.isIdentity()) {
 		if (continued) {

--- a/src/main/java/tech/units/indriya/format/SimpleUnitFormat.java
+++ b/src/main/java/tech/units/indriya/format/SimpleUnitFormat.java
@@ -54,7 +54,7 @@ import javax.measure.format.UnitFormat;
 import tech.units.indriya.AbstractUnit;
 import tech.units.indriya.function.AddConverter;
 import tech.units.indriya.function.MultiplyConverter;
-import tech.units.indriya.function.PowerConverter;
+import tech.units.indriya.function.PowersOfIntConverter;
 import tech.units.indriya.function.RationalConverter;
 import tech.units.indriya.unit.AlternateUnit;
 import tech.units.indriya.unit.AnnotatedUnit;
@@ -105,7 +105,7 @@ public abstract class SimpleUnitFormat extends AbstractUnitFormat {
 
   private static final UnitConverter[] PREFIX_CONVERTERS =  
 		  Stream.of(PREFIXES)
-		  .map(PowerConverter::of)
+		  .map(PowersOfIntConverter::of)
 		  .collect(Collectors.toList())
   		  .toArray(new UnitConverter[] {});
 

--- a/src/main/java/tech/units/indriya/function/AddConverter.java
+++ b/src/main/java/tech/units/indriya/function/AddConverter.java
@@ -93,7 +93,7 @@ public final class AddConverter extends AbstractConverter implements ValueSuppli
   }
   
   @Override
-  public AddConverter inverse() {
+  public AddConverter inverseWhenNotIdentity() {
     return new AddConverter(-offset);
   }
 
@@ -108,8 +108,8 @@ public final class AddConverter extends AbstractConverter implements ValueSuppli
   }
 
   @Override
-  public final String toString() {
-    return "AddConverter(" + offset + ")";
+  public String transformationLiteral() {
+    return String.format("x -> x %s %s", offset < 0 ? "-" : "+", Math.abs(offset));
   }
 
   @Override

--- a/src/main/java/tech/units/indriya/function/ExpConverter.java
+++ b/src/main/java/tech/units/indriya/function/ExpConverter.java
@@ -48,138 +48,142 @@ import tech.uom.lib.common.function.ValueSupplier;
  *
  * @author <a href="mailto:jean-marie@dautelle.com">Jean-Marie Dautelle</a>
  * @author <a href="mailto:units@catmedia.us">Werner Keil</a>
- * @version 1.2, March 25, 2018
+ * @author Andi Huber
+ * @version 1.3, April 26, 2018
  * @since 1.0
  */
 public final class ExpConverter extends AbstractConverter implements ValueSupplier<String> {
 
-  /**
+	/**
 	 * 
 	 */
-  private static final long serialVersionUID = -8851436813812059827L;
+	private static final long serialVersionUID = -8851436813812059827L;
 
-  /**
-   * Holds the logarithmic base.
-   */
-  private final double base;
+	/**
+	 * Holds the logarithmic base.
+	 */
+	private final double base;
 
-  /**
-   * Holds the natural logarithm of the base.
-   */
-  private final double logOfBase;
+	/**
+	 * Holds the natural logarithm of the base.
+	 */
+	private final double logOfBase;
 
-  /**
-   * Creates a logarithmic converter having the specified base.
-   *
-   * @param base
-   *          the logarithmic base (e.g. <code>Math.E</code> for the Natural Logarithm).
-   */
-  public ExpConverter(double base) {
-    this.base = base;
-    this.logOfBase = Math.log(base);
-  }
-
-  /**
-   * Creates a logarithmic converter having the specified base.
-   *
-   * @param base
-   *          the logarithmic base (e.g. <code>Math.E</code> for the Natural Logarithm).
-   */
-  public static ExpConverter of(double base) {
-    return new ExpConverter(base);
-  }
-
-  /**
-   * Returns the exponential base of this converter.
-   *
-   * @return the exponential base (e.g. <code>Math.E</code> for the Natural Exponential).
-   */
-  public double getBase() {
-    return base;
-  }
-
-  @Override
-  public boolean isIdentity() {
-    return false;
-  }
-
-  @Override
-  protected boolean isSimpleCompositionWith(AbstractConverter that) {
-	if(that instanceof LogConverter) {
-		return ((LogConverter)that).getBase() == base; // can compose with log to identity, provided it has same base
+	/**
+	 * Creates a logarithmic converter having the specified base.
+	 *
+	 * @param base
+	 *          the logarithmic base (e.g. <code>Math.E</code> for the Natural Logarithm).
+	 */
+	public ExpConverter(double base) {
+		this.base = base;
+		this.logOfBase = Math.log(base);
 	}
-  	return false;
-  }
 
-  @Override
-  protected AbstractConverter simpleCompose(AbstractConverter that) {
-    return AbstractConverter.IDENTITY;
-  }
-  
-  @Override
-  public AbstractConverter inverse() {
-    return new LogConverter(base);
-  }
+	/**
+	 * Creates a logarithmic converter having the specified base.
+	 *
+	 * @param base
+	 *          the logarithmic base (e.g. <code>Math.E</code> for the Natural Logarithm).
+	 */
+	public static ExpConverter of(double base) {
+		return new ExpConverter(base);
+	}
 
-  @Override
-  public final String toString() {
-    if (base == Math.E) {
-      return "e";
-    } else {
-      return "Exp(" + base + ")";
-    }
-  }
+	/**
+	 * Returns the exponential base of this converter.
+	 *
+	 * @return the exponential base (e.g. <code>Math.E</code> for the Natural Exponential).
+	 */
+	public double getBase() {
+		return base;
+	}
 
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj instanceof ExpConverter) {
-      ExpConverter that = (ExpConverter) obj;
-      return Objects.equals(base, that.base);
-    }
-    return false;
-  }
+	@Override
+	public boolean isIdentity() {
+		return false;
+	}
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(base);
-  }
+	@Override
+	protected boolean isSimpleCompositionWith(AbstractConverter that) {
+		if(that instanceof LogConverter) {
+			return ((LogConverter)that).getBase() == base; // can compose with log to identity, provided it has same base
+		}
+		return false;
+	}
 
-  @Override
-  public double convertWhenNotIdentity(double amount) {
-    return Math.exp(logOfBase * amount);
-  }
+	@Override
+	protected AbstractConverter simpleCompose(AbstractConverter that) {
+		return AbstractConverter.IDENTITY;
+	}
 
-  @Override
-  public BigDecimal convertWhenNotIdentity(BigDecimal value, MathContext ctx) throws ArithmeticException {
-    return BigDecimal.valueOf(convert(value.doubleValue())); // Reverts to
-    // double
-    // conversion.
-  }
+	@Override
+	public AbstractConverter inverseWhenNotIdentity() {
+		return new LogConverter(base);
+	}
 
-  @Override
-  public boolean isLinear() {
-    return false;
-  }
+	@Override
+	public final String transformationLiteral() {
+		if (base == Math.E) {
+			return "x -> e^x";
+		} else {
+			if(base<0) {
+				return String.format("x -> (%s)^x", base);
+			}
+			return String.format("x -> %s^x", base);
+		}
+	}
 
-  @Override
-  public String getValue() {
-    return toString();
-  }
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj instanceof ExpConverter) {
+			ExpConverter that = (ExpConverter) obj;
+			return Objects.equals(base, that.base);
+		}
+		return false;
+	}
 
-  @SuppressWarnings("rawtypes")
-  @Override
-  public int compareTo(UnitConverter o) {
-    if (this == o) {
-      return 0;
-    }
-    if (o instanceof ValueSupplier) {
-      return getValue().compareTo(String.valueOf(((ValueSupplier) o).getValue()));
-    }
-    return -1;
-  }
+	@Override
+	public int hashCode() {
+		return Objects.hash(base);
+	}
+
+	@Override
+	public double convertWhenNotIdentity(double amount) {
+		return Math.exp(logOfBase * amount);
+	}
+
+	@Override
+	public BigDecimal convertWhenNotIdentity(BigDecimal value, MathContext ctx) throws ArithmeticException {
+		return BigDecimal.valueOf(convert(value.doubleValue())); // Reverts to
+		// double
+		// conversion.
+	}
+
+	@Override
+	public boolean isLinear() {
+		return false;
+	}
+
+	@Override
+	public String getValue() {
+		return toString();
+	}
+
+	@SuppressWarnings("rawtypes")
+	@Override
+	public int compareTo(UnitConverter o) {
+		if (this == o) {
+			return 0;
+		}
+		if (o instanceof ValueSupplier) {
+			return getValue().compareTo(String.valueOf(((ValueSupplier) o).getValue()));
+		}
+		return -1;
+	}
 
 
 }

--- a/src/main/java/tech/units/indriya/function/LogConverter.java
+++ b/src/main/java/tech/units/indriya/function/LogConverter.java
@@ -49,122 +49,122 @@ import tech.uom.lib.common.function.ValueSupplier;
  * @since 1.0
  */
 public final class LogConverter extends AbstractConverter implements ValueSupplier<String> { // implements
-  // Immutable<String>
-  // {
+	// Immutable<String>
+	// {
 
-  /**
-     * 
-     */
-  private static final long serialVersionUID = -7584688290961460870L;
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = -7584688290961460870L;
 
-  /**
-   * Holds the logarithmic base.
-   */
-  private final double base;
-  /**
-   * Holds the natural logarithm of the base.
-   */
-  private final double logOfBase;
+	/**
+	 * Holds the logarithmic base.
+	 */
+	private final double base;
+	/**
+	 * Holds the natural logarithm of the base.
+	 */
+	private final double logOfBase;
 
-  /**
-   * Returns a logarithmic converter having the specified base.
-   *
-   * @param base
-   *          the logarithmic base (e.g. <code>Math.E</code> for the Natural Logarithm).
-   */
-  public LogConverter(double base) {
-    this.base = base;
-    this.logOfBase = Math.log(base);
-  }
-
-  /**
-   * Returns the logarithmic base of this converter.
-   *
-   * @return the logarithmic base (e.g. <code>Math.E</code> for the Natural Logarithm).
-   */
-  public double getBase() {
-    return base;
-  }
-  
-  @Override
-  public boolean isIdentity() {
-    return false;
-  }
-
-  @Override
-  protected boolean isSimpleCompositionWith(AbstractConverter that) {
-	if(that instanceof ExpConverter) {
-		return ((ExpConverter)that).getBase() == base; // can compose with exp to identity, provided it has same base
+	/**
+	 * Returns a logarithmic converter having the specified base.
+	 *
+	 * @param base
+	 *          the logarithmic base (e.g. <code>Math.E</code> for the Natural Logarithm).
+	 */
+	public LogConverter(double base) {
+		this.base = base;
+		this.logOfBase = Math.log(base);
 	}
-  	return false;
-  }
 
-  @Override
-  protected AbstractConverter simpleCompose(AbstractConverter that) {
-    return AbstractConverter.IDENTITY;
-  }
+	/**
+	 * Returns the logarithmic base of this converter.
+	 *
+	 * @return the logarithmic base (e.g. <code>Math.E</code> for the Natural Logarithm).
+	 */
+	public double getBase() {
+		return base;
+	}
 
-  @Override
-  public AbstractConverter inverse() {
-    return new ExpConverter(base);
-  }
+	@Override
+	public boolean isIdentity() {
+		return false;
+	}
 
-  @Override
-  public final String toString() {
-    if (base == Math.E) {
-      return "ln";
-    } else {
-      return "Log(" + base + ")";
-    }
-  }
+	@Override
+	protected boolean isSimpleCompositionWith(AbstractConverter that) {
+		if(that instanceof ExpConverter) {
+			return ((ExpConverter)that).getBase() == base; // can compose with exp to identity, provided it has same base
+		}
+		return false;
+	}
 
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-    if (obj instanceof LogConverter) {
-      LogConverter that = (LogConverter) obj;
-      return Objects.equals(base, that.base);
-    }
-    return false;
-  }
+	@Override
+	protected AbstractConverter simpleCompose(AbstractConverter that) {
+		return AbstractConverter.IDENTITY;
+	}
 
-  @Override
-  public int hashCode() {
-    return Objects.hash(base);
-  }
+	@Override
+	public AbstractConverter inverseWhenNotIdentity() {
+		return new ExpConverter(base);
+	}
 
-  @Override
-  public double convertWhenNotIdentity(double amount) {
-    return Math.log(amount) / logOfBase;
-  }
+	@Override
+	public final String transformationLiteral() {
+		if (base == Math.E) {
+			return "x -> ln(x)";
+		} else {
+			return String.format("x -> log(base=%s, x)", base);
+		}
+	}
+	
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj instanceof LogConverter) {
+			LogConverter that = (LogConverter) obj;
+			return Objects.equals(base, that.base);
+		}
+		return false;
+	}
 
-  @Override
-  public BigDecimal convertWhenNotIdentity(BigDecimal value, MathContext ctx) throws ArithmeticException {
-    return BigDecimal.valueOf(convert(value.doubleValue())); // Reverts to
-    // double
-    // conversion.
-  }
+	@Override
+	public int hashCode() {
+		return Objects.hash(base);
+	}
 
-  @Override
-  public boolean isLinear() {
-    return false;
-  }
+	@Override
+	public double convertWhenNotIdentity(double amount) {
+		return Math.log(amount) / logOfBase;
+	}
 
-  @Override
-  public String getValue() {
-    return toString();
-  }
+	@Override
+	public BigDecimal convertWhenNotIdentity(BigDecimal value, MathContext ctx) throws ArithmeticException {
+		return BigDecimal.valueOf(convert(value.doubleValue())); // Reverts to
+		// double
+		// conversion.
+	}
 
-  @Override
-  public int compareTo(UnitConverter o) {
-    if (this == o) {
-      return 0;
-    }
-    if (o instanceof ValueSupplier) {
-      return getValue().compareTo(String.valueOf(((ValueSupplier<?>) o).getValue()));
-    }
-    return -1;
-  }
+	@Override
+	public boolean isLinear() {
+		return false;
+	}
+
+	@Override
+	public String getValue() {
+		return toString();
+	}
+
+	@Override
+	public int compareTo(UnitConverter o) {
+		if (this == o) {
+			return 0;
+		}
+		if (o instanceof ValueSupplier) {
+			return getValue().compareTo(String.valueOf(((ValueSupplier<?>) o).getValue()));
+		}
+		return -1;
+	}
 }

--- a/src/main/java/tech/units/indriya/function/MultiplyConverter.java
+++ b/src/main/java/tech/units/indriya/function/MultiplyConverter.java
@@ -107,7 +107,7 @@ public final class MultiplyConverter extends AbstractConverter implements ValueS
 	}
 
 	@Override
-	public MultiplyConverter inverse() {
+	public MultiplyConverter inverseWhenNotIdentity() {
 		return new MultiplyConverter(1.0 / factor);
 	}
 
@@ -122,8 +122,8 @@ public final class MultiplyConverter extends AbstractConverter implements ValueS
 	}
 
 	@Override
-	public final String toString() {
-		return MultiplyConverter.class.getSimpleName() + "(" + factor + ")";
+	public final String transformationLiteral() {
+		return String.format("x -> x * %s", factor);
 	}
 
 	@Override

--- a/src/main/java/tech/units/indriya/function/PiPowerConverter.java
+++ b/src/main/java/tech/units/indriya/function/PiPowerConverter.java
@@ -32,6 +32,8 @@ package tech.units.indriya.function;
 
 import java.math.BigDecimal;
 import java.math.MathContext;
+import java.util.Objects;
+
 import javax.measure.UnitConverter;
 
 import tech.units.indriya.AbstractConverter;
@@ -44,9 +46,13 @@ import tech.units.indriya.AbstractConverter;
  * @version 1.0, April 24, 2018
  * @since 2.0
  */
-public final class PiPowerConverter extends PowerConverter {
+public final class PiPowerConverter extends AbstractConverter {
 
 	private static final long serialVersionUID = 5000593326722785126L;
+	
+	private final int exponent;
+	private final int hashCode;
+	private final double doubleFactor; // for double calculus only
 
 	/**
 	 * Creates a converter with the specified exponent.
@@ -59,12 +65,23 @@ public final class PiPowerConverter extends PowerConverter {
 	}
 
 	protected PiPowerConverter(int exponent) {
-		super(Math.PI, exponent);
+		this.exponent = exponent;
+		this.doubleFactor =  Math.pow(Math.PI, exponent);
+		this.hashCode = Objects.hash(exponent);
+	}
+
+	public int getExponent() {
+		return exponent;
 	}
 
 	@Override
 	public boolean isIdentity() {
 		return exponent == 0; // x^0 = 1, for any x!=0
+	}
+
+	@Override
+	public boolean isLinear() {
+		return true;
 	}
 
 	@Override
@@ -135,4 +152,10 @@ public final class PiPowerConverter extends PowerConverter {
 		}
 		return this.getClass().getName().compareTo(o.getClass().getName());
 	}
+
+	@Override
+	public int hashCode() {
+		return hashCode;
+	}
+
 }

--- a/src/main/java/tech/units/indriya/function/PowerConverter.java
+++ b/src/main/java/tech/units/indriya/function/PowerConverter.java
@@ -48,13 +48,13 @@ import tech.units.indriya.Calculus;
  * @version 1.1, April 24, 2018
  * @since 2.0
  */
-public class PowerConverter extends AbstractConverter {
+public final class PowerConverter extends AbstractConverter {
 	private static final long serialVersionUID = 3546932001671571300L;
 
-	protected final int base;
-	protected final int exponent;
-	protected final int hashCode;
-	protected final double doubleFactor; // for double calculus only
+	private final int base;
+	private final int exponent;
+	private final int hashCode;
+	private final double doubleFactor; // for double calculus only
 
 	/**
 	 * Creates a converter with the specified Prefix.
@@ -82,16 +82,6 @@ public class PowerConverter extends AbstractConverter {
 			throw new IllegalArgumentException("base cannot be zero (because 0^0 is undefined)");
 		}
 		this.base = base;
-		this.exponent = exponent;
-		this.doubleFactor = Math.pow(base, exponent);
-		this.hashCode = Objects.hash(base, exponent);
-	}
-	
-	protected PowerConverter(double base, int exponent) {
-		if(base == 0) {
-			throw new IllegalArgumentException("base cannot be zero (because 0^0 is undefined)");
-		}
-		this.base = (int)base;
 		this.exponent = exponent;
 		this.doubleFactor = Math.pow(base, exponent);
 		this.hashCode = Objects.hash(base, exponent);

--- a/src/main/java/tech/units/indriya/function/PowersOfIntConverter.java
+++ b/src/main/java/tech/units/indriya/function/PowersOfIntConverter.java
@@ -48,7 +48,7 @@ import tech.units.indriya.Calculus;
  * @version 1.1, April 24, 2018
  * @since 2.0
  */
-public final class PowerConverter extends AbstractConverter {
+public final class PowersOfIntConverter extends AbstractConverter {
 	private static final long serialVersionUID = 3546932001671571300L;
 
 	private final int base;
@@ -62,8 +62,8 @@ public final class PowerConverter extends AbstractConverter {
 	 * @param prefix
 	 *            the prefix for the factor.
 	 */
-	public static PowerConverter of(Prefix prefix) {
-		return new PowerConverter(prefix.getBase(), prefix.getExponent());
+	public static PowersOfIntConverter of(Prefix prefix) {
+		return new PowersOfIntConverter(prefix.getBase(), prefix.getExponent());
 	}
 
 	/**
@@ -73,11 +73,11 @@ public final class PowerConverter extends AbstractConverter {
 	 * @param exponent
 	 * @return
 	 */
-	public static PowerConverter of(int base, int exponent) {
-		return new PowerConverter(base, exponent);
+	public static PowersOfIntConverter of(int base, int exponent) {
+		return new PowersOfIntConverter(base, exponent);
 	}
 
-	protected PowerConverter(int base, int exponent) {
+	protected PowersOfIntConverter(int base, int exponent) {
 		if(base == 0) {
 			throw new IllegalArgumentException("base cannot be zero (because 0^0 is undefined)");
 		}
@@ -112,16 +112,16 @@ public final class PowerConverter extends AbstractConverter {
 
 	@Override
 	protected boolean isSimpleCompositionWith(AbstractConverter that) {
-		if (that instanceof PowerConverter) {
-			return ((PowerConverter) that).base == this.base;
+		if (that instanceof PowersOfIntConverter) {
+			return ((PowersOfIntConverter) that).base == this.base;
 		}
 		return that.isLinear();
 	}
 
 	@Override
 	protected AbstractConverter simpleCompose(AbstractConverter that) {
-		if (that instanceof PowerConverter) {
-			PowerConverter other = (PowerConverter) that;
+		if (that instanceof PowersOfIntConverter) {
+			PowersOfIntConverter other = (PowersOfIntConverter) that;
 			if(this.base == other.base) { // always true due to guard above
 				return composeSameBaseNonIdentity(other);
 			} 
@@ -140,7 +140,7 @@ public final class PowerConverter extends AbstractConverter {
 
 	@Override
 	public AbstractConverter inverse() {
-		return isIdentity() ? this : new PowerConverter(base, -exponent);
+		return isIdentity() ? this : new PowersOfIntConverter(base, -exponent);
 	}
 
 	@Override
@@ -197,8 +197,8 @@ public final class PowerConverter extends AbstractConverter {
 				return true;
 			}
 		}
-		if (obj instanceof PowerConverter) {
-			PowerConverter other = (PowerConverter) obj;
+		if (obj instanceof PowersOfIntConverter) {
+			PowersOfIntConverter other = (PowersOfIntConverter) obj;
 			return this.base == other.base && this.exponent == other.exponent;
 		}
 		return false;
@@ -217,8 +217,8 @@ public final class PowerConverter extends AbstractConverter {
 		if(this.isIdentity() && o.isIdentity()) {
 			return 0;
 		}
-		if (o instanceof PowerConverter) {
-			PowerConverter other = (PowerConverter) o;
+		if (o instanceof PowersOfIntConverter) {
+			PowersOfIntConverter other = (PowersOfIntConverter) o;
 			int c = Integer.compare(base, other.base);
 			if(c!=0) {
 				return c;
@@ -235,9 +235,9 @@ public final class PowerConverter extends AbstractConverter {
 
 	// -- HELPER
 
-	private PowerConverter composeSameBaseNonIdentity(PowerConverter other) {
+	private PowersOfIntConverter composeSameBaseNonIdentity(PowersOfIntConverter other) {
 		// no check for identity required
-		return new PowerConverter(this.base, this.exponent + other.exponent);
+		return new PowersOfIntConverter(this.base, this.exponent + other.exponent);
 	}
 
 	public RationalConverter toRationalConverter() {

--- a/src/main/java/tech/units/indriya/function/PowersOfIntConverter.java
+++ b/src/main/java/tech/units/indriya/function/PowersOfIntConverter.java
@@ -139,8 +139,8 @@ public final class PowersOfIntConverter extends AbstractConverter {
 	}
 
 	@Override
-	public AbstractConverter inverse() {
-		return isIdentity() ? this : new PowersOfIntConverter(base, -exponent);
+	public AbstractConverter inverseWhenNotIdentity() {
+		return new PowersOfIntConverter(base, -exponent);
 	}
 
 	@Override
@@ -205,8 +205,11 @@ public final class PowersOfIntConverter extends AbstractConverter {
 	}
 
 	@Override
-	public String toString() {
-		return "PiPowerConverter(^" + exponent + ")";
+	public final String transformationLiteral() {
+		if(base<0) {
+			return String.format("x -> x * (%s)^%s", base, exponent);
+		}
+		return String.format("x -> x * %s^%s", base, exponent);
 	}
 
 	@Override

--- a/src/main/java/tech/units/indriya/function/PowersOfPiConverter.java
+++ b/src/main/java/tech/units/indriya/function/PowersOfPiConverter.java
@@ -85,8 +85,8 @@ public final class PowersOfPiConverter extends AbstractConverter {
 	}
 
 	@Override
-	public AbstractConverter inverse() {
-		return isIdentity() ? this : new PowersOfPiConverter(-exponent);
+	public AbstractConverter inverseWhenNotIdentity() {
+		return new PowersOfPiConverter(-exponent);
 	}
 
 	@Override
@@ -134,8 +134,8 @@ public final class PowersOfPiConverter extends AbstractConverter {
 	}
 
 	@Override
-	public final String toString() {
-		return "PiPowerConverter(π^" + exponent + ")";
+	public final String transformationLiteral() {
+		return String.format("x -> x * π^%s", exponent);
 	}
 
 	@Override

--- a/src/main/java/tech/units/indriya/function/PowersOfPiConverter.java
+++ b/src/main/java/tech/units/indriya/function/PowersOfPiConverter.java
@@ -46,7 +46,7 @@ import tech.units.indriya.AbstractConverter;
  * @version 1.0, April 24, 2018
  * @since 2.0
  */
-public final class PiPowerConverter extends AbstractConverter {
+public final class PowersOfPiConverter extends AbstractConverter {
 
 	private static final long serialVersionUID = 5000593326722785126L;
 	
@@ -60,11 +60,11 @@ public final class PiPowerConverter extends AbstractConverter {
 	 * @param exponent
 	 *            the exponent for the factor π^exponent.
 	 */
-	public static PiPowerConverter of(int exponent) {
-		return new PiPowerConverter(exponent);
+	public static PowersOfPiConverter of(int exponent) {
+		return new PowersOfPiConverter(exponent);
 	}
 
-	protected PiPowerConverter(int exponent) {
+	protected PowersOfPiConverter(int exponent) {
 		this.exponent = exponent;
 		this.doubleFactor =  Math.pow(Math.PI, exponent);
 		this.hashCode = Objects.hash(exponent);
@@ -86,7 +86,7 @@ public final class PiPowerConverter extends AbstractConverter {
 
 	@Override
 	public AbstractConverter inverse() {
-		return isIdentity() ? this : new PiPowerConverter(-exponent);
+		return isIdentity() ? this : new PowersOfPiConverter(-exponent);
 	}
 
 	@Override
@@ -107,12 +107,12 @@ public final class PiPowerConverter extends AbstractConverter {
 
 	@Override
 	protected boolean isSimpleCompositionWith(AbstractConverter that) {
-		return that instanceof PiPowerConverter;
+		return that instanceof PowersOfPiConverter;
 	}
 
 	@Override
 	protected AbstractConverter simpleCompose(AbstractConverter that) {
-		return new PiPowerConverter(this.exponent + ((PiPowerConverter)that).exponent);
+		return new PowersOfPiConverter(this.exponent + ((PowersOfPiConverter)that).exponent);
 	}
 
 	@Override
@@ -126,8 +126,8 @@ public final class PiPowerConverter extends AbstractConverter {
 				return true;
 			}
 		}
-		if (obj instanceof PiPowerConverter) {
-			PiPowerConverter other = (PiPowerConverter) obj;
+		if (obj instanceof PowersOfPiConverter) {
+			PowersOfPiConverter other = (PowersOfPiConverter) obj;
 			return this.exponent == other.exponent;
 		}
 		return false;
@@ -146,8 +146,8 @@ public final class PiPowerConverter extends AbstractConverter {
 		if(this.isIdentity() && o.isIdentity()) {
 			return 0;
 		}
-		if (o instanceof PiPowerConverter) {
-			PiPowerConverter other = (PiPowerConverter) o;
+		if (o instanceof PowersOfPiConverter) {
+			PowersOfPiConverter other = (PowersOfPiConverter) o;
 			return Integer.compare(exponent, other.exponent);
 		}
 		return this.getClass().getName().compareTo(o.getClass().getName());

--- a/src/main/java/tech/units/indriya/function/RationalConverter.java
+++ b/src/main/java/tech/units/indriya/function/RationalConverter.java
@@ -239,7 +239,7 @@ public final class RationalConverter extends AbstractConverter implements ValueS
 
 	@Override
 	public final String transformationLiteral() {
-		return String.format("(%s)/(%s)", dividend, divisor);
+		return String.format("x -> x * (%s)/(%s)", dividend, divisor);
 	}
 
 	@Override

--- a/src/main/java/tech/units/indriya/function/RationalConverter.java
+++ b/src/main/java/tech/units/indriya/function/RationalConverter.java
@@ -232,14 +232,14 @@ public final class RationalConverter extends AbstractConverter implements ValueS
 
 
 	@Override
-	public RationalConverter inverse() {
+	public RationalConverter inverseWhenNotIdentity() {
 		return dividend.signum() == -1 ? new RationalConverter(getDivisor().negate(), getDividend().negate()) : new RationalConverter(getDivisor(),
 				getDividend());
 	}
 
 	@Override
-	public final String toString() {
-		return "RationalConverter(" + dividend + "," + divisor + ")";
+	public final String transformationLiteral() {
+		return String.format("(%s)/(%s)", dividend, divisor);
 	}
 
 	@Override

--- a/src/main/java/tech/units/indriya/function/RationalConverter.java
+++ b/src/main/java/tech/units/indriya/function/RationalConverter.java
@@ -213,7 +213,7 @@ public final class RationalConverter extends AbstractConverter implements ValueS
 		if (that instanceof RationalConverter) {
 			return true; 
 		}
-		return that instanceof PowerConverter;
+		return that instanceof PowersOfIntConverter;
 	}
 
 	@Override
@@ -221,9 +221,9 @@ public final class RationalConverter extends AbstractConverter implements ValueS
 		if (that instanceof RationalConverter) {
 			return (AbstractConverter) composeSameType((RationalConverter) that); 
 		}
-		if (that instanceof PowerConverter) {
+		if (that instanceof PowersOfIntConverter) {
 			//TODO [ahuber] check whether this can be expressed as a PowerConverter, if so return a PowerConverter
-			return (AbstractConverter) composeSameType(((PowerConverter) that).toRationalConverter()); 
+			return (AbstractConverter) composeSameType(((PowersOfIntConverter) that).toRationalConverter()); 
 		}
 		throw new IllegalStateException(String.format(
 				"%s.simpleCompose() not handled for linear converter %s", 

--- a/src/main/java/tech/units/indriya/quantity/BigIntegerQuantity.java
+++ b/src/main/java/tech/units/indriya/quantity/BigIntegerQuantity.java
@@ -110,7 +110,12 @@ final class BigIntegerQuantity<Q extends Quantity<Q>> extends AbstractQuantity<Q
       return Quantities.getQuantity(value.add(Calculus.toBigInteger(that.getValue())), getUnit());
     }
     Quantity<Q> converted = that.to(getUnit());
-    return Quantities.getQuantity(value.add(Calculus.toBigInteger(converted.getValue())), getUnit());
+    Unit<Q> unit = getUnit();
+    if(Calculus.isLessThanOne(Calculus.abs(converted.getValue()))) {
+    	converted = this.to(that.getUnit());
+    	unit = that.getUnit();
+    }
+    return Quantities.getQuantity(value.add(Calculus.toBigInteger(converted.getValue())), unit);
   }
 
   @Override

--- a/src/main/java/tech/units/indriya/quantity/time/TimeQuantities.java
+++ b/src/main/java/tech/units/indriya/quantity/time/TimeQuantities.java
@@ -47,7 +47,7 @@ import javax.measure.Quantity;
 import javax.measure.Unit;
 import javax.measure.quantity.Time;
 
-import tech.units.indriya.function.PowerConverter;
+import tech.units.indriya.function.PowersOfIntConverter;
 import tech.units.indriya.quantity.Quantities;
 import tech.units.indriya.unit.TransformedUnit;
 import tech.units.indriya.unit.Units;
@@ -66,13 +66,13 @@ public final class TimeQuantities {
 	// Convenience constants outside the unit system (multiples are not held there)
 
 	public static final Unit<Time> MICROSECOND = new TransformedUnit<>("μs", SECOND, SECOND,
-			PowerConverter.of(MetricPrefix.MICRO));
+			PowersOfIntConverter.of(MetricPrefix.MICRO));
 
 	public static final TransformedUnit<Time> MILLISECOND = new TransformedUnit<>("ms", SECOND, SECOND,
-			PowerConverter.of(MetricPrefix.MILLI));
+			PowersOfIntConverter.of(MetricPrefix.MILLI));
 
 	public static final TransformedUnit<Time> NANOSECOND = new TransformedUnit<>("ns", SECOND, SECOND,
-			PowerConverter.of(MetricPrefix.NANO));
+			PowersOfIntConverter.of(MetricPrefix.NANO));
 
 	/**
 	 * Creates the {@link Quantity<Time>} based in the difference of the two

--- a/src/test/java/tech/units/indriya/function/AddConverterTest.java
+++ b/src/test/java/tech/units/indriya/function/AddConverterTest.java
@@ -74,7 +74,8 @@ public class AddConverterTest {
 
   @Test
   public void toStringTest() {
-    assertEquals("AddConverter(10.0)", converter.toString());
+    assertEquals("Add(x -> x + 10.0)", converter.toString());
+    assertEquals("Add(x -> x - 10.0)", converter.inverse().toString());
   }
 
   @Test

--- a/src/test/java/tech/units/indriya/function/CompositionEquivalenceTest.java
+++ b/src/test/java/tech/units/indriya/function/CompositionEquivalenceTest.java
@@ -66,10 +66,10 @@ public class CompositionEquivalenceTest {
 				()->AbstractConverter.IDENTITY,
 				AbstractConverter.IDENTITY, 
 				AbstractConverter.IDENTITY	),
-		POWER(PowerConverter.class, 
-				()->PowerConverter.of(1, 0),
-				PowerConverter.of(3, 7), 
-				PowerConverter.of(7, -3)	),
+		POWER(PowersOfIntConverter.class, 
+				()->PowersOfIntConverter.of(1, 0),
+				PowersOfIntConverter.of(3, 7), 
+				PowersOfIntConverter.of(7, -3)	),
 		RATIONAL(RationalConverter.class, 
 				()->RationalConverter.of(1, 1),
 				RationalConverter.of(17, 13),
@@ -90,10 +90,10 @@ public class CompositionEquivalenceTest {
 				null, // exp has no identity variant
 				new ExpConverter(4.5),
 				new ExpConverter(0.1) ),
-		PI(PiPowerConverter.class, 
-				()->PiPowerConverter.of(0), // log has no identity variant
-				PiPowerConverter.of(1),
-				PiPowerConverter.of(-1) ),
+		PI(PowersOfPiConverter.class, 
+				()->PowersOfPiConverter.of(0), // log has no identity variant
+				PowersOfPiConverter.of(1),
+				PowersOfPiConverter.of(-1) ),
 		// when adding entries, also increment the typeCount!
 		;
 

--- a/src/test/java/tech/units/indriya/function/ExpConverterTest.java
+++ b/src/test/java/tech/units/indriya/function/ExpConverterTest.java
@@ -61,8 +61,8 @@ public class ExpConverterTest {
   @Test
   public void testGetValueLogConverter() {
     ExpConverter expConverter = new ExpConverter(Math.E);
-    assertEquals("Exp(10.0)", expConverterBase10.getValue());
-    assertEquals("e", expConverter.getValue());
+    assertEquals("Exp(x -> 10.0^x)", expConverterBase10.getValue());
+    assertEquals("Exp(x -> e^x)", expConverter.getValue());
   }
 
   @Test

--- a/src/test/java/tech/units/indriya/function/LogConverterTest.java
+++ b/src/test/java/tech/units/indriya/function/LogConverterTest.java
@@ -61,8 +61,8 @@ public class LogConverterTest {
   @Test
   public void testGetValueLogConverter() {
     LogConverter logConverter = new LogConverter(Math.E);
-    assertEquals("Log(10.0)", logConverterBase10.getValue());
-    assertEquals("ln", logConverter.getValue());
+    assertEquals("Log(x -> log(base=10.0, x))", logConverterBase10.getValue());
+    assertEquals("Log(x -> ln(x))", logConverter.getValue());
   }
 
   @Test

--- a/src/test/java/tech/units/indriya/function/MultiplyConverterTest.java
+++ b/src/test/java/tech/units/indriya/function/MultiplyConverterTest.java
@@ -87,6 +87,6 @@ public class MultiplyConverterTest {
 
   @Test
   public void toStringTest() {
-    assertEquals("MultiplyConverter(2.0)", converter.toString());
+    assertEquals("Multiply(x -> x * 2.0)", converter.toString());
   }
 }

--- a/src/test/java/tech/units/indriya/function/PowersOfPiConverterTest.java
+++ b/src/test/java/tech/units/indriya/function/PowersOfPiConverterTest.java
@@ -56,7 +56,7 @@ public class PiPowerConverterTest {
 	
 	@Test
 	public void testConvertMethod() {
-		PiPowerConverter converter = new PiPowerConverter(-1);
+		PowersOfPiConverter converter = new PowersOfPiConverter(-1);
 		Calculus.MATH_CONTEXT = MathContext.DECIMAL32;
 		
 		assertEquals(1000, converter.convert(3141), 0.2);
@@ -66,7 +66,7 @@ public class PiPowerConverterTest {
 
 	@Test
 	public void testConvertBigDecimalMethod() {
-		PiPowerConverter converter = new PiPowerConverter(-1);
+		PowersOfPiConverter converter = new PowersOfPiConverter(-1);
 		Calculus.MATH_CONTEXT = MathContext.DECIMAL32;
 		
 		assertEquals(1000, converter.convert(new BigDecimal("3141")).doubleValue(), 0.2);
@@ -76,36 +76,36 @@ public class PiPowerConverterTest {
 
 	@Test
 	public void testEquality() {
-		PiPowerConverter a = new PiPowerConverter(-1);
-		PiPowerConverter b = new PiPowerConverter(-1);
-		PiPowerConverter c = new PiPowerConverter(1);
+		PowersOfPiConverter a = new PowersOfPiConverter(-1);
+		PowersOfPiConverter b = new PowersOfPiConverter(-1);
+		PowersOfPiConverter c = new PowersOfPiConverter(1);
 		assertTrue(a.equals(b)); 
 		assertFalse(a.equals(c));
 	}
 
 	@Test
 	public void isLinear() {
-		PiPowerConverter converter = new PiPowerConverter(-1);
+		PowersOfPiConverter converter = new PowersOfPiConverter(-1);
 		assertTrue(converter.isLinear());
 	}
 	
 	@Test
 	public void piSquaredBigDecimalDefaultPrecision() {
-		PiPowerConverter converter = new PiPowerConverter(2);
+		PowersOfPiConverter converter = new PowersOfPiConverter(2);
 		BigDecimal value = (BigDecimal) converter.convert(BigDecimal.valueOf(0.1));
 		assertEquals("0.9869604401089358618834490999876151", value.toPlainString());
 	}
 	
 	@Test
 	public void piBigDecimalDefaultPrecision() {
-		PiPowerConverter converter = new PiPowerConverter(1);
+		PowersOfPiConverter converter = new PowersOfPiConverter(1);
 		Calculus.MATH_CONTEXT = MathContext.UNLIMITED;
 		assertThrows(ArithmeticException.class, ()->converter.convert(BigDecimal.valueOf(1.0)));
 	}
 	
 	@Test
 	public void piBigDecimalExtendedPrecision() {
-		PiPowerConverter converter = new PiPowerConverter(1);
+		PowersOfPiConverter converter = new PowersOfPiConverter(1);
 		Calculus.MATH_CONTEXT = new MathContext(MathContext.DECIMAL128.getPrecision() * 2);
 		BigDecimal value = (BigDecimal) converter.convert(BigDecimal.valueOf(1.));
 		assertEquals(

--- a/src/test/java/tech/units/indriya/function/PowersOfPiConverterTest.java
+++ b/src/test/java/tech/units/indriya/function/PowersOfPiConverterTest.java
@@ -42,8 +42,12 @@ import org.junit.jupiter.api.Test;
 
 import tech.units.indriya.Calculus;
 
-public class PiPowerConverterTest {
+public class PowersOfPiConverterTest {
 
+	// for reference
+	protected final static String HUNDRED_DIGITS_OF_PI =
+			"3.141592653589793238462643383279502884197169399375105820974944592307816406286208998628034825342117068";
+	
 //	@BeforeEach
 //	public void setUp() throws Exception {
 //		
@@ -108,6 +112,8 @@ public class PiPowerConverterTest {
 		PowersOfPiConverter converter = new PowersOfPiConverter(1);
 		Calculus.MATH_CONTEXT = new MathContext(MathContext.DECIMAL128.getPrecision() * 2);
 		BigDecimal value = (BigDecimal) converter.convert(BigDecimal.valueOf(1.));
+		//[ahuber] last digit should actually round to '2' instead of '0', 
+		// but I suppose this is within margin of error
 		assertEquals(
 				"3.14159265358979323846264338327950288419716939937510582097494459230780", 
 				value.toPlainString());

--- a/src/test/java/tech/units/indriya/function/PowersOfPiConverterTest.java
+++ b/src/test/java/tech/units/indriya/function/PowersOfPiConverterTest.java
@@ -47,22 +47,22 @@ public class PowersOfPiConverterTest {
 	// for reference
 	protected final static String HUNDRED_DIGITS_OF_PI =
 			"3.141592653589793238462643383279502884197169399375105820974944592307816406286208998628034825342117068";
-	
-//	@BeforeEach
-//	public void setUp() throws Exception {
-//		
-//	}
+
+	//	@BeforeEach
+	//	public void setUp() throws Exception {
+	//		
+	//	}
 
 	@AfterEach
 	public void reset() throws Exception {
 		Calculus.MATH_CONTEXT = Calculus.DEFAULT_MATH_CONTEXT;
 	}
-	
+
 	@Test
 	public void testConvertMethod() {
 		PowersOfPiConverter converter = new PowersOfPiConverter(-1);
 		Calculus.MATH_CONTEXT = MathContext.DECIMAL32;
-		
+
 		assertEquals(1000, converter.convert(3141), 0.2);
 		assertEquals(0, converter.convert(0));
 		assertEquals(-1000, converter.convert(-3141), 0.2);
@@ -72,7 +72,7 @@ public class PowersOfPiConverterTest {
 	public void testConvertBigDecimalMethod() {
 		PowersOfPiConverter converter = new PowersOfPiConverter(-1);
 		Calculus.MATH_CONTEXT = MathContext.DECIMAL32;
-		
+
 		assertEquals(1000, converter.convert(new BigDecimal("3141")).doubleValue(), 0.2);
 		assertEquals(0, converter.convert(BigDecimal.ZERO).doubleValue());
 		assertEquals(-1000, converter.convert(new BigDecimal("-3141")).doubleValue(), 0.2);
@@ -92,21 +92,21 @@ public class PowersOfPiConverterTest {
 		PowersOfPiConverter converter = new PowersOfPiConverter(-1);
 		assertTrue(converter.isLinear());
 	}
-	
+
 	@Test
 	public void piSquaredBigDecimalDefaultPrecision() {
 		PowersOfPiConverter converter = new PowersOfPiConverter(2);
 		BigDecimal value = (BigDecimal) converter.convert(BigDecimal.valueOf(0.1));
 		assertEquals("0.9869604401089358618834490999876151", value.toPlainString());
 	}
-	
+
 	@Test
 	public void piBigDecimalDefaultPrecision() {
 		PowersOfPiConverter converter = new PowersOfPiConverter(1);
 		Calculus.MATH_CONTEXT = MathContext.UNLIMITED;
 		assertThrows(ArithmeticException.class, ()->converter.convert(BigDecimal.valueOf(1.0)));
 	}
-	
+
 	@Test
 	public void piBigDecimalExtendedPrecision() {
 		PowersOfPiConverter converter = new PowersOfPiConverter(1);
@@ -118,5 +118,11 @@ public class PowersOfPiConverterTest {
 				"3.14159265358979323846264338327950288419716939937510582097494459230780", 
 				value.toPlainString());
 	}
-	
+
+	@Test
+	public void toStringTest() {
+		PowersOfPiConverter converter = new PowersOfPiConverter(2);
+		assertEquals("PowersOfPi(x -> x * π^2)", converter.toString());
+	}
+
 }

--- a/src/test/java/tech/units/indriya/quantity/BigIntegerQuantityTest.java
+++ b/src/test/java/tech/units/indriya/quantity/BigIntegerQuantityTest.java
@@ -29,10 +29,13 @@
  */
 package tech.units.indriya.quantity;
 
+import static javax.measure.MetricPrefix.MILLI;
+import static javax.measure.MetricPrefix.YOTTA;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.math.BigInteger;
 
+import javax.measure.MetricPrefix;
 import javax.measure.Quantity;
 import javax.measure.quantity.ElectricResistance;
 import javax.measure.quantity.Length;
@@ -40,9 +43,6 @@ import javax.measure.quantity.Time;
 
 import org.junit.jupiter.api.Test;
 
-import tech.units.indriya.quantity.BigIntegerQuantity;
-import tech.units.indriya.quantity.Quantities;
-import static javax.measure.MetricPrefix.*;
 import tech.units.indriya.unit.Units;
 
 public class BigIntegerQuantityTest {
@@ -116,27 +116,58 @@ public class BigIntegerQuantityTest {
 
   @Test
   public void milliOhmTest() {
-    final BigIntegerQuantity<ElectricResistance> ONE_OHM = new BigIntegerQuantity<ElectricResistance>(Long.valueOf(1), Units.OHM);
-    final BigIntegerQuantity<ElectricResistance> ONE_MILLIOHM = new BigIntegerQuantity<ElectricResistance>(Long.valueOf(1),
-        MILLI(Units.OHM));
-
-    assertEquals(ONE_OHM, ONE_OHM.add(ONE_MILLIOHM));
-    final BigIntegerQuantity<ElectricResistance> ONEOONE_MILLIOHM = new BigIntegerQuantity<ElectricResistance>(Long.valueOf(1001),
-        MILLI(Units.OHM));
-    assertEquals(ONEOONE_MILLIOHM, ONE_MILLIOHM.add(ONE_OHM));
+    final BigIntegerQuantity<ElectricResistance> ONE_OHM = 
+    		new BigIntegerQuantity<ElectricResistance>(1L, Units.OHM);
+    final BigIntegerQuantity<ElectricResistance> ONE_MILLIOHM = 
+    		new BigIntegerQuantity<ElectricResistance>(1L, MILLI(Units.OHM));
+    final BigIntegerQuantity<ElectricResistance> expected = 
+    		new BigIntegerQuantity<ElectricResistance>(1001L, MILLI(Units.OHM));
+    
+    assertEquals(expected, ONE_OHM.add(ONE_MILLIOHM));
+    assertEquals(expected, ONE_MILLIOHM.add(ONE_OHM));
   }
 
   @Test
   public void yottaOhmTest() {
     final BigIntegerQuantity<ElectricResistance> ONE_OHM = 
-    		new BigIntegerQuantity<ElectricResistance>(Long.valueOf(1), Units.OHM);
-    
+    		new BigIntegerQuantity<ElectricResistance>(1L, Units.OHM);
     final BigIntegerQuantity<ElectricResistance> ONE_YOTTAOHM = 
-    		new BigIntegerQuantity<ElectricResistance>(Long.valueOf(1), YOTTA(Units.OHM));
-    
-    final BigIntegerQuantity<ElectricResistance> RESULT_OHM = 
+    		new BigIntegerQuantity<ElectricResistance>(1L, YOTTA(Units.OHM));
+    final BigIntegerQuantity<ElectricResistance> expected = 
     		new BigIntegerQuantity<ElectricResistance>(BigInteger.TEN.pow(24).add(BigInteger.ONE), Units.OHM);
     
-    assertEquals(RESULT_OHM, ONE_OHM.add(ONE_YOTTAOHM));
+    assertEquals(expected, ONE_OHM.add(ONE_YOTTAOHM));
+    assertEquals(expected, ONE_YOTTAOHM.add(ONE_OHM));
   }
+  
+  
+  @Test
+  public void bigIntQuantityAdditionUsingOhm() {
+
+	  final BigIntegerQuantity<ElectricResistance> ONE_OHM = 
+			  new BigIntegerQuantity<ElectricResistance>(1L, Units.OHM);
+
+	  for(MetricPrefix prefix : MetricPrefix.values()) {
+
+		  final String msg = String.format("testing 1 Ω + 1 %sΩ", prefix.getSymbol());
+
+		  final BigIntegerQuantity<ElectricResistance> operand = 
+				  new BigIntegerQuantity<ElectricResistance>(1L, Units.OHM.prefix(prefix));
+
+		  final BigIntegerQuantity<ElectricResistance> expected;
+		  if(prefix.getExponent() > 0) {
+			  expected = new BigIntegerQuantity<ElectricResistance>(
+					  BigInteger.TEN.pow(prefix.getExponent()).add(BigInteger.ONE), Units.OHM);
+		  } else {
+			  expected = new BigIntegerQuantity<ElectricResistance>(
+					  BigInteger.TEN.pow(-prefix.getExponent()).add(BigInteger.ONE), Units.OHM.prefix(prefix));
+		  }
+
+		  assertEquals(expected, ONE_OHM.add(operand), msg);
+		  assertEquals(expected, operand.add(ONE_OHM), msg);
+	  }
+
+  }
+  
+  
 }

--- a/src/test/java/tech/units/indriya/quantity/BigIntegerQuantityTest.java
+++ b/src/test/java/tech/units/indriya/quantity/BigIntegerQuantityTest.java
@@ -41,6 +41,7 @@ import javax.measure.quantity.ElectricResistance;
 import javax.measure.quantity.Length;
 import javax.measure.quantity.Time;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import tech.units.indriya.unit.Units;
@@ -115,7 +116,8 @@ public class BigIntegerQuantityTest {
   }
 
   @Test
-  public void milliOhmTest() {
+  @DisplayName("1 Ω + 1 mΩ should to be 1001 mΩ")
+  public void milliOhm1() {
     final BigIntegerQuantity<ElectricResistance> ONE_OHM = 
     		new BigIntegerQuantity<ElectricResistance>(1L, Units.OHM);
     final BigIntegerQuantity<ElectricResistance> ONE_MILLIOHM = 
@@ -125,6 +127,34 @@ public class BigIntegerQuantityTest {
     
     assertEquals(expected, ONE_OHM.add(ONE_MILLIOHM));
     assertEquals(expected, ONE_MILLIOHM.add(ONE_OHM));
+  }
+  
+  @Test
+  @DisplayName("1 Ω + 1001 mΩ should to be 2001 mΩ")
+  public void milliOhm2() {
+    final BigIntegerQuantity<ElectricResistance> ONE_OHM = 
+    		new BigIntegerQuantity<ElectricResistance>(1L, Units.OHM);
+    final BigIntegerQuantity<ElectricResistance> operand = 
+    		new BigIntegerQuantity<ElectricResistance>(1001L, MILLI(Units.OHM));
+    final BigIntegerQuantity<ElectricResistance> expected = 
+    		new BigIntegerQuantity<ElectricResistance>(2001L, MILLI(Units.OHM));
+    
+    assertEquals(expected, ONE_OHM.add(operand));
+    assertEquals(expected, operand.add(ONE_OHM));
+  }
+  
+  @Test
+  @DisplayName("1 Ω - 1001 mΩ should to be -1 mΩ")
+  public void milliOhm3() {
+    final BigIntegerQuantity<ElectricResistance> ONE_OHM = 
+    		new BigIntegerQuantity<ElectricResistance>(1L, Units.OHM);
+    final BigIntegerQuantity<ElectricResistance> operand = 
+    		new BigIntegerQuantity<ElectricResistance>(1001L, MILLI(Units.OHM));
+    final BigIntegerQuantity<ElectricResistance> expected = 
+    		new BigIntegerQuantity<ElectricResistance>(-1L, MILLI(Units.OHM));
+    
+    assertEquals(expected, ONE_OHM.subtract(operand));
+    assertEquals(expected, operand.subtract(ONE_OHM).multiply(-1));
   }
 
   @Test

--- a/src/test/java/tech/units/indriya/quantity/BigIntegerQuantityTest.java
+++ b/src/test/java/tech/units/indriya/quantity/BigIntegerQuantityTest.java
@@ -116,7 +116,7 @@ public class BigIntegerQuantityTest {
   }
 
   @Test
-  @DisplayName("1 Ω + 1 mΩ should to be 1001 mΩ")
+  @DisplayName("1 Ω + 1 mΩ should be 1001 mΩ")
   public void milliOhm1() {
     final BigIntegerQuantity<ElectricResistance> ONE_OHM = 
     		new BigIntegerQuantity<ElectricResistance>(1L, Units.OHM);
@@ -130,7 +130,7 @@ public class BigIntegerQuantityTest {
   }
   
   @Test
-  @DisplayName("1 Ω + 1001 mΩ should to be 2001 mΩ")
+  @DisplayName("1 Ω + 1001 mΩ should be 2001 mΩ")
   public void milliOhm2() {
     final BigIntegerQuantity<ElectricResistance> ONE_OHM = 
     		new BigIntegerQuantity<ElectricResistance>(1L, Units.OHM);
@@ -144,7 +144,7 @@ public class BigIntegerQuantityTest {
   }
   
   @Test
-  @DisplayName("1 Ω - 1001 mΩ should to be -1 mΩ")
+  @DisplayName("1 Ω - 1001 mΩ should be -1 mΩ")
   public void milliOhm3() {
     final BigIntegerQuantity<ElectricResistance> ONE_OHM = 
     		new BigIntegerQuantity<ElectricResistance>(1L, Units.OHM);


### PR DESCRIPTION
Also providing a `toString` method in `AbstractConverter` that is final. Provides a format that is more precise about the kind of transformation a `Converter` represents.

Updates and additions to existing tests were also made.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/indriya/65)
<!-- Reviewable:end -->
