### PR TITLE
Add --batch-mode to Maven commands in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,7 +38,7 @@ jobs:
           key: v1-dependencies-{{ checksum "pom.xml" }}
         
       # run tests!
-      - run: mvn test jacoco:report
+      - run: mvn --batch-mode test jacoco:report
       
       - run: bash <(curl -s https://codecov.io/bash)
   deployment:
@@ -75,7 +75,7 @@ jobs:
           key: v1-dependencies-{{ checksum "pom.xml" }}
         
       # run deployment!
-      - run: mvn deploy -Dmaven.test.skip -DcreateDocs=true -s settings.xml
+      - run: mvn --batch-mode deploy -Dmaven.test.skip -DcreateDocs=true -s settings.xml
 workflows:
   version: 2
   build_deploy:


### PR DESCRIPTION
--batch-mode is more convenient for CI services since it avoids
unnecessary expansion of the build output.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/indriya/90)
<!-- Reviewable:end -->
