### PR TITLE
20 improve code coverage default quantity factory unit tests

### DIFF
--- a/src/main/java/tech/units/indriya/quantity/DefaultQuantityFactory.java
+++ b/src/main/java/tech/units/indriya/quantity/DefaultQuantityFactory.java
@@ -109,8 +109,7 @@ import javax.measure.spi.QuantityFactory;
 import tech.units.indriya.AbstractUnit;
 
 /**
- * A factory producing simple quantities instances (tuples {@link Number}/
- * {@link Unit}).<br>
+ * A factory producing simple quantities instances (tuples {@link Number}/ {@link Unit}).<br>
  *
  * For example:<br>
  * <code>
@@ -119,10 +118,9 @@ import tech.units.indriya.AbstractUnit;
  * </code>
  * 
  * @param <Q>
- *            The type of the quantity.
+ *          The type of the quantity.
  *
- * @author <a href="mailto:martin.desruisseaux@geomatys.com">Martin
- *         Desruisseaux</a>
+ * @author <a href="mailto:martin.desruisseaux@geomatys.com">Martin Desruisseaux</a>
  * @author <a href="mailto:units@catmedia.us">Werner Keil</a>
  * @author <a href="mailto:jean-marie@dautelle.com">Jean-Marie Dautelle</a>
  * @author <a href="mailto:otaviojava@java.net">Otavio Santana</a>
@@ -130,122 +128,119 @@ import tech.units.indriya.AbstractUnit;
  * @since 1.0
  */
 public class DefaultQuantityFactory<Q extends Quantity<Q>> implements QuantityFactory<Q> {
-	@SuppressWarnings("rawtypes")
-	static final Map<Class, QuantityFactory> INSTANCES = new HashMap<>();
+  @SuppressWarnings("rawtypes")
+  static final Map<Class, QuantityFactory> INSTANCES = new HashMap<>();
 
-	static final Logger logger = Logger.getLogger(DefaultQuantityFactory.class.getName());
+  static final Logger logger = Logger.getLogger(DefaultQuantityFactory.class.getName());
 
-	static final Level LOG_LEVEL = Level.FINE;
+  static final Level LOG_LEVEL = Level.FINE;
 
-	/**
-	 * The type of the quantities created by this factory.
-	 */
-	private final Class<Q> type;
+  /**
+   * The type of the quantities created by this factory.
+   */
+  private final Class<Q> type;
 
-	/**
-	 * The system unit for quantities created by this factory.
-	 */
-	private final Unit<Q> systemUnit;
+  /**
+   * The system unit for quantities created by this factory.
+   */
+  private final Unit<Q> systemUnit;
 
-	@SuppressWarnings("rawtypes")
-	private static final Map<Class, Unit> CLASS_TO_SYSTEM_UNIT = new ConcurrentHashMap<>();
+  @SuppressWarnings("rawtypes")
+  private static final Map<Class, Unit> CLASS_TO_SYSTEM_UNIT = new ConcurrentHashMap<>();
 
-	static {
-		CLASS_TO_SYSTEM_UNIT.put(Dimensionless.class, AbstractUnit.ONE);
-		CLASS_TO_SYSTEM_UNIT.put(ElectricCurrent.class, AMPERE);
-		CLASS_TO_SYSTEM_UNIT.put(LuminousIntensity.class, CANDELA);
-		CLASS_TO_SYSTEM_UNIT.put(Temperature.class, KELVIN);
-		CLASS_TO_SYSTEM_UNIT.put(Mass.class, KILOGRAM);
-		CLASS_TO_SYSTEM_UNIT.put(Length.class, METRE);
-		CLASS_TO_SYSTEM_UNIT.put(AmountOfSubstance.class, MOLE);
-		CLASS_TO_SYSTEM_UNIT.put(Time.class, SECOND);
-		CLASS_TO_SYSTEM_UNIT.put(Angle.class, RADIAN);
-		CLASS_TO_SYSTEM_UNIT.put(SolidAngle.class, STERADIAN);
-		CLASS_TO_SYSTEM_UNIT.put(Frequency.class, HERTZ);
-		CLASS_TO_SYSTEM_UNIT.put(Force.class, NEWTON);
-		CLASS_TO_SYSTEM_UNIT.put(Pressure.class, PASCAL);
-		CLASS_TO_SYSTEM_UNIT.put(Energy.class, JOULE);
-		CLASS_TO_SYSTEM_UNIT.put(Power.class, WATT);
-		CLASS_TO_SYSTEM_UNIT.put(ElectricCharge.class, COULOMB);
-		CLASS_TO_SYSTEM_UNIT.put(ElectricPotential.class, VOLT);
-		CLASS_TO_SYSTEM_UNIT.put(ElectricCapacitance.class, FARAD);
-		CLASS_TO_SYSTEM_UNIT.put(ElectricResistance.class, OHM);
-		CLASS_TO_SYSTEM_UNIT.put(ElectricConductance.class, SIEMENS);
-		CLASS_TO_SYSTEM_UNIT.put(MagneticFlux.class, WEBER);
-		CLASS_TO_SYSTEM_UNIT.put(MagneticFluxDensity.class, TESLA);
-		CLASS_TO_SYSTEM_UNIT.put(ElectricInductance.class, HENRY);
-		CLASS_TO_SYSTEM_UNIT.put(LuminousFlux.class, LUMEN);
-		CLASS_TO_SYSTEM_UNIT.put(Illuminance.class, LUX);
-		CLASS_TO_SYSTEM_UNIT.put(Radioactivity.class, BECQUEREL);
-		CLASS_TO_SYSTEM_UNIT.put(RadiationDoseAbsorbed.class, GRAY);
-		CLASS_TO_SYSTEM_UNIT.put(RadiationDoseEffective.class, SIEVERT);
-		CLASS_TO_SYSTEM_UNIT.put(CatalyticActivity.class, KATAL);
-		CLASS_TO_SYSTEM_UNIT.put(Speed.class, METRE_PER_SECOND);
-		CLASS_TO_SYSTEM_UNIT.put(Acceleration.class, METRE_PER_SQUARE_SECOND);
-		CLASS_TO_SYSTEM_UNIT.put(Area.class, SQUARE_METRE);
-		CLASS_TO_SYSTEM_UNIT.put(Volume.class, CUBIC_METRE);
-	}
+  static {
+    CLASS_TO_SYSTEM_UNIT.put(Dimensionless.class, AbstractUnit.ONE);
+    CLASS_TO_SYSTEM_UNIT.put(ElectricCurrent.class, AMPERE);
+    CLASS_TO_SYSTEM_UNIT.put(LuminousIntensity.class, CANDELA);
+    CLASS_TO_SYSTEM_UNIT.put(Temperature.class, KELVIN);
+    CLASS_TO_SYSTEM_UNIT.put(Mass.class, KILOGRAM);
+    CLASS_TO_SYSTEM_UNIT.put(Length.class, METRE);
+    CLASS_TO_SYSTEM_UNIT.put(AmountOfSubstance.class, MOLE);
+    CLASS_TO_SYSTEM_UNIT.put(Time.class, SECOND);
+    CLASS_TO_SYSTEM_UNIT.put(Angle.class, RADIAN);
+    CLASS_TO_SYSTEM_UNIT.put(SolidAngle.class, STERADIAN);
+    CLASS_TO_SYSTEM_UNIT.put(Frequency.class, HERTZ);
+    CLASS_TO_SYSTEM_UNIT.put(Force.class, NEWTON);
+    CLASS_TO_SYSTEM_UNIT.put(Pressure.class, PASCAL);
+    CLASS_TO_SYSTEM_UNIT.put(Energy.class, JOULE);
+    CLASS_TO_SYSTEM_UNIT.put(Power.class, WATT);
+    CLASS_TO_SYSTEM_UNIT.put(ElectricCharge.class, COULOMB);
+    CLASS_TO_SYSTEM_UNIT.put(ElectricPotential.class, VOLT);
+    CLASS_TO_SYSTEM_UNIT.put(ElectricCapacitance.class, FARAD);
+    CLASS_TO_SYSTEM_UNIT.put(ElectricResistance.class, OHM);
+    CLASS_TO_SYSTEM_UNIT.put(ElectricConductance.class, SIEMENS);
+    CLASS_TO_SYSTEM_UNIT.put(MagneticFlux.class, WEBER);
+    CLASS_TO_SYSTEM_UNIT.put(MagneticFluxDensity.class, TESLA);
+    CLASS_TO_SYSTEM_UNIT.put(ElectricInductance.class, HENRY);
+    CLASS_TO_SYSTEM_UNIT.put(LuminousFlux.class, LUMEN);
+    CLASS_TO_SYSTEM_UNIT.put(Illuminance.class, LUX);
+    CLASS_TO_SYSTEM_UNIT.put(Radioactivity.class, BECQUEREL);
+    CLASS_TO_SYSTEM_UNIT.put(RadiationDoseAbsorbed.class, GRAY);
+    CLASS_TO_SYSTEM_UNIT.put(RadiationDoseEffective.class, SIEVERT);
+    CLASS_TO_SYSTEM_UNIT.put(CatalyticActivity.class, KATAL);
+    CLASS_TO_SYSTEM_UNIT.put(Speed.class, METRE_PER_SECOND);
+    CLASS_TO_SYSTEM_UNIT.put(Acceleration.class, METRE_PER_SQUARE_SECOND);
+    CLASS_TO_SYSTEM_UNIT.put(Area.class, SQUARE_METRE);
+    CLASS_TO_SYSTEM_UNIT.put(Volume.class, CUBIC_METRE);
+  }
 
-	@SuppressWarnings("unchecked")
-	private DefaultQuantityFactory(Class<Q> quantity) {
-		type = quantity;
-		systemUnit = CLASS_TO_SYSTEM_UNIT.get(type);
-	}
+  @SuppressWarnings("unchecked")
+  private DefaultQuantityFactory(Class<Q> quantity) {
+    type = quantity;
+    systemUnit = CLASS_TO_SYSTEM_UNIT.get(type);
+  }
 
-	/**
-	 * Returns the default instance for the specified quantity type.
-	 *
-	 * @param <Q>
-	 *            The type of the quantity
-	 * @param type
-	 *            the quantity type
-	 * @return the quantity factory for the specified type
-	 */
-	@SuppressWarnings("unchecked")
-	public static <Q extends Quantity<Q>> QuantityFactory<Q> getInstance(final Class<Q> type) {
-		logger.log(LOG_LEVEL, "Type: " + type + ": " + type.isInterface());
-		QuantityFactory<Q> factory;
-		if (!type.isInterface()) {
-			factory = new DefaultQuantityFactory<Q>(type);
-			// TODO use instances?
-		} else {
-			factory = INSTANCES.get(type);
-			if (factory != null)
-				return factory;
-			if (!Quantity.class.isAssignableFrom(type))
-				// This exception is not documented because it should never
-				// happen if the
-				// user don't try to trick the Java generic types system with
-				// unsafe cast.
-				throw new ClassCastException();
-			factory = new DefaultQuantityFactory<Q>(type);
-			INSTANCES.put(type, factory);
-		}
-		return factory;
-	}
+  /**
+   * Returns the default instance for the specified quantity type.
+   *
+   * @param <Q>
+   *          The type of the quantity
+   * @param type
+   *          the quantity type
+   * @return the quantity factory for the specified type
+   */
+  @SuppressWarnings("unchecked")
+  public static <Q extends Quantity<Q>> QuantityFactory<Q> getInstance(final Class<Q> type) {
+    logger.log(LOG_LEVEL, "Type: " + type + ": " + type.isInterface());
+    QuantityFactory<Q> factory;
+    factory = INSTANCES.get(type);
+    if (factory != null) {
+      return factory;
+    }
+    if (!Quantity.class.isAssignableFrom(type)) {
+      // This exception is not documented because it should never
+      // happen if the
+      // user don't try to trick the Java generic types system with
+      // unsafe cast.
+      throw new ClassCastException();
+    }
+    factory = new DefaultQuantityFactory<Q>(type);
+    INSTANCES.put(type, factory);
+    return factory;
+  }
 
-	public String toString() {
-		return "tech.units.indriya.DefaultQuantityFactory <" + type.getName() + '>';
-	}
+  public String toString() {
+    return "tech.units.indriya.DefaultQuantityFactory <" + type.getName() + '>';
+  }
 
-	public boolean equals(Object obj) {
-		if (DefaultQuantityFactory.class.isInstance(obj)) {
-			@SuppressWarnings("rawtypes")
-			DefaultQuantityFactory other = DefaultQuantityFactory.class.cast(obj);
-			return Objects.equals(type, other.type);
-		}
-		return false;
-	}
+  public boolean equals(Object obj) {
+    if (DefaultQuantityFactory.class.isInstance(obj)) {
+      @SuppressWarnings("rawtypes")
+      DefaultQuantityFactory other = DefaultQuantityFactory.class.cast(obj);
+      return Objects.equals(type, other.type);
+    }
+    return false;
+  }
 
-	public int hashCode() {
-		return type.hashCode();
-	}
+  public int hashCode() {
+    return type.hashCode();
+  }
 
-	public Quantity<Q> create(Number value, Unit<Q> unit) {
-		return Quantities.getQuantity(value, unit);
-	}
+  public Quantity<Q> create(Number value, Unit<Q> unit) {
+    return Quantities.getQuantity(value, unit);
+  }
 
-	public Unit<Q> getSystemUnit() {
-		return systemUnit;
-	}
+  public Unit<Q> getSystemUnit() {
+    return systemUnit;
+  }
 }

--- a/src/test/java/tech/units/indriya/quantity/DefaultQuantityFactoryTest.java
+++ b/src/test/java/tech/units/indriya/quantity/DefaultQuantityFactoryTest.java
@@ -1,0 +1,221 @@
+/*
+ * Units of Measurement Reference Implementation
+ * Copyright (c) 2005-2018, Jean-Marie Dautelle, Werner Keil, Otavio Santana.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of JSR-385, Indriya nor the names of their contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package tech.units.indriya.quantity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import static tech.units.indriya.unit.Units.METRE;
+
+import javax.measure.Quantity;
+import javax.measure.quantity.Length;
+import javax.measure.spi.QuantityFactory;
+
+import org.junit.jupiter.api.Test;
+
+import tech.units.indriya.unit.Units;
+
+/**
+ * @author Werner Keil
+ */
+public class DefaultQuantityFactoryTest {
+
+  private QuantityFactory<Length> lengthFactory = DefaultQuantityFactory.getInstance(Length.class);
+  private QuantityFactory<QuantityInterface> testFactory = DefaultQuantityFactory.getInstance(QuantityInterface.class);
+
+  /**
+   * Local quantity interface to test the instance methods on.
+   */
+  interface QuantityInterface extends Quantity<QuantityInterface> {
+  }
+
+  /**
+   * Verifies that the factory throws an exception if an instance is requested for null.
+   */
+  @Test
+  public void getInstanceThrowsExceptionForNull() {
+    assertThrows(Exception.class, () -> {
+      DefaultQuantityFactory.getInstance(null);
+    });
+  }
+
+  /**
+   * Local quantity interface that hasn't been registered in the factory yet. This interface should only be used by the unit test method verifying
+   * that the factory creates an instance for an unregistered quantity interface.
+   */
+  interface OneTimeUnregisteredQuantityInterface extends Quantity<OneTimeUnregisteredQuantityInterface> {
+  }
+
+  /**
+   * Verifies that the factory returns a new instance for an unregistered quantity interface.
+   */
+  @Test
+  public void getInstanceCreatesAFactoryForAnUnregisteredQuantityInterface() {
+    assertNotNull(DefaultQuantityFactory.getInstance(OneTimeUnregisteredQuantityInterface.class));
+  }
+
+  /**
+   * Local quantity interface that hasn't been registered in the factory yet. This interface should only be used by the unit test method verifying
+   * that the factory doesn't create multiple instances for the same quantity interface.
+   */
+  interface TwoTimesUnregisteredQuantityInterface extends Quantity<TwoTimesUnregisteredQuantityInterface> {
+  }
+
+  /**
+   * Verifies that the factory doesn't create a new instance the second time a previously unregistered quantity interface is requested.
+   */
+  @Test
+  public void getInstanceDoesNotCreateTwoFactoriesForAnUnregisteredQuantityInterface() {
+    QuantityFactory<TwoTimesUnregisteredQuantityInterface> instance1 = DefaultQuantityFactory
+        .getInstance(TwoTimesUnregisteredQuantityInterface.class);
+    QuantityFactory<TwoTimesUnregisteredQuantityInterface> instance2 = DefaultQuantityFactory
+        .getInstance(TwoTimesUnregisteredQuantityInterface.class);
+    assertTrue(instance1 == instance2);
+  }
+
+  /**
+   * Local quantity class that hasn't been registered in the factory yet. This class should only be used by the unit test method verifying that the
+   * factory creates an instance for an unregistered quantity class.
+   */
+  abstract class OneTimeUnregisteredQuantityClass implements Quantity<OneTimeUnregisteredQuantityClass> {
+  }
+
+  /**
+   * Verifies that the factory returns a new instance for an unregistered quantity class.
+   */
+  @Test
+  public void getInstanceCreatesAFactoryForAnUnregisteredQuantityClass() {
+    assertNotNull(DefaultQuantityFactory.getInstance(OneTimeUnregisteredQuantityClass.class));
+  }
+
+  /**
+   * Local quantity class that hasn't been registered in the factory yet. This class should only be used by the unit test method verifying that the
+   * factory doesn't create multiple instances for the same quantity class.
+   */
+  abstract class TwoTimesUnregisteredQuantityClass implements Quantity<TwoTimesUnregisteredQuantityClass> {
+  }
+
+  /**
+   * Verifies that the factory doesn't create a new instance the second time a previously unregistered quantity class is requested.
+   */
+  @Test
+  public void getInstanceDoesNotCreateTwoFactoriesForAnUnregisteredQuantityClass() {
+    QuantityFactory<TwoTimesUnregisteredQuantityClass> instance1 = DefaultQuantityFactory.getInstance(TwoTimesUnregisteredQuantityClass.class);
+    QuantityFactory<TwoTimesUnregisteredQuantityClass> instance2 = DefaultQuantityFactory.getInstance(TwoTimesUnregisteredQuantityClass.class);
+    assertTrue(instance1 == instance2);
+  }
+
+  /**
+   * Local quantity class that hasn't been registered in the factory yet and that implements a non-quantity interface too. This class should only be
+   * used by the unit test method verifying that the factory creates an instance for an unregistered quantity class implementing an extra interface.
+   */
+  abstract class OneTimeComparableUnregisteredQuantityClass
+      implements Comparable<OneTimeComparableUnregisteredQuantityClass>, Quantity<OneTimeComparableUnregisteredQuantityClass> {
+  }
+
+  /**
+   * Verifies that the factory returns a new instance for an unregistered quantity class implementing an extra interface.
+   */
+  @Test
+  public void getInstanceCreatesAFactoryForAnUnregisteredQuantityClassWithExtraInterface() {
+    assertNotNull(DefaultQuantityFactory.getInstance(OneTimeComparableUnregisteredQuantityClass.class));
+  }
+
+  /**
+   * Verifies that a quantity created via DefaultQuantityFactory is equal to one created by the Quantities facade.
+   */
+  @Test
+  public void testQuantityIsEqualToNumberQuantity() {
+    final Quantity<Length> actual = lengthFactory.create(10, Units.METRE);
+    final Quantity<Length> expected = Quantities.getQuantity(10, Units.METRE);
+    assertEquals(expected, actual);
+  }
+
+  /**
+   * Verifies that a quantity factory isn't equal to null.
+   */
+  @Test
+  public void defaultQuantityFactoryIsNotEqualToNull() {
+    assertFalse(testFactory.equals(null));
+  }
+
+  /**
+   * Verifies that a quantity factory is equal to itself.
+   */
+  @Test
+  public void defaultQuantityFactoryIsEqualToItself() {
+    assertTrue(testFactory.equals(testFactory));
+  }
+
+  /**
+   * Verifies that a quantity factory is not equal to a quantity factory for a different type.
+   */
+  @Test
+  public void testQuantityIsNotEqualToQuantityWithDifferentValue() {
+    assertFalse(testFactory.equals(lengthFactory));
+  }
+
+  /**
+   * Verifies that the hash codes of two factories that aren't equal aren't equal. Notice that this isn't a strict requirement on the hashCode method,
+   * and that hash collisions may occur, but in general, objects that aren't equal shouldn't have an equal hash code.
+   */
+  @Test
+  public void hashCodeShouldBeDifferentForDifferentFactories() {
+    assertFalse(testFactory.hashCode() == lengthFactory.hashCode());
+  }
+
+  /**
+   * Verifies that a quantity factory is not equal to an object of a different class.
+   */
+  @Test
+  public void testQuantityIsNotEqualToObjectOfDifferentClass() {
+    assertFalse(testFactory.equals(Length.class));
+  }
+
+  /**
+   * Verifies that the toString method produces the correct text.
+   */
+  @Test
+  public void toStringMustProduceCorrectText() {
+    assertEquals("tech.units.indriya.DefaultQuantityFactory <tech.units.indriya.quantity.DefaultQuantityFactoryTest$QuantityInterface>",
+        testFactory.toString());
+  }
+
+  /**
+   * Verifies that the length factory returns the meter as the system unit.
+   */
+  @Test
+  public void lengthFactoryMustReturnMeterAsSystemUnit() {
+    assertEquals(METRE, lengthFactory.getSystemUnit());
+  }
+}

--- a/src/test/java/tech/units/indriya/quantity/DefaultQuantityFactoryTest.java
+++ b/src/test/java/tech/units/indriya/quantity/DefaultQuantityFactoryTest.java
@@ -156,8 +156,8 @@ public class DefaultQuantityFactoryTest {
    */
   @Test
   public void testQuantityIsEqualToNumberQuantity() {
-    final Quantity<Length> actual = lengthFactory.create(10, Units.METRE);
-    final Quantity<Length> expected = Quantities.getQuantity(10, Units.METRE);
+    final Quantity<Length> actual = lengthFactory.create(10, METRE);
+    final Quantity<Length> expected = Quantities.getQuantity(10, METRE);
     assertEquals(expected, actual);
   }
 

--- a/src/test/java/tech/units/indriya/quantity/ProxyQuantityFactoryTest.java
+++ b/src/test/java/tech/units/indriya/quantity/ProxyQuantityFactoryTest.java
@@ -108,7 +108,7 @@ public class ProxyQuantityFactoryTest {
         .getInstance(TwoTimesUnregisteredQuantityInterface.class);
     ProxyQuantityFactory<TwoTimesUnregisteredQuantityInterface> instance2 = ProxyQuantityFactory
         .getInstance(TwoTimesUnregisteredQuantityInterface.class);
-    assertEquals(instance1, instance2);
+    assertTrue(instance1 == instance2);
   }
 
   /**
@@ -140,7 +140,7 @@ public class ProxyQuantityFactoryTest {
   public void getInstanceDoesNotCreateTwoFactoriesForAnUnregisteredQuantityClass() {
     QuantityFactory<TwoTimesUnregisteredQuantityClass> instance1 = ProxyQuantityFactory.getInstance(TwoTimesUnregisteredQuantityClass.class);
     QuantityFactory<TwoTimesUnregisteredQuantityClass> instance2 = ProxyQuantityFactory.getInstance(TwoTimesUnregisteredQuantityClass.class);
-    assertEquals(instance1, instance2);
+    assertTrue(instance1 == instance2);
   }
 
   /**
@@ -248,16 +248,16 @@ public class ProxyQuantityFactoryTest {
       testQuantity.inverse();
     });
   }
-  
+
   /**
    * Verifies that a quantity created via ProxyQuantityFactory is equal to one created by the Quantities facade.
    */
   @Test
   public void testQuantityIsEqualToNumberQuantity() {
-	final QuantityFactory<Length> lenFactory = ProxyQuantityFactory.getInstance(Length.class);
-	final Quantity<Length> len1 = lenFactory.create(10, Units.METRE);
-	final Quantity<Length> len2 = Quantities.getQuantity(10, Units.METRE);
+    final QuantityFactory<Length> lenFactory = ProxyQuantityFactory.getInstance(Length.class);
+    final Quantity<Length> len1 = lenFactory.create(10, Units.METRE);
+    final Quantity<Length> len2 = Quantities.getQuantity(10, Units.METRE);
     assertEquals(len1, len2);
   }
-  
+
 }


### PR DESCRIPTION
Work for issue #20.

Note that there is one change to the behavior of `DefaultQuantityFactory`: `getInstance` now also stores instances for types that are classes, not just interfaces, such that it doesn't return a new instance each time the method is invoked with a non-interface type.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/indriya/107)
<!-- Reviewable:end -->
