### PR TITLE
QuantityDimension: Fixed divide(Dimension dim) where dim is a product

### DIFF
--- a/src/main/java/tech/units/indriya/quantity/QuantityDimension.java
+++ b/src/main/java/tech/units/indriya/quantity/QuantityDimension.java
@@ -35,6 +35,7 @@ import javax.measure.Unit;
 
 import tech.units.indriya.AbstractUnit;
 import tech.units.indriya.unit.BaseUnit;
+import tech.units.indriya.unit.ProductUnit;
 import tech.units.indriya.unit.Units;
 
 import java.io.Serializable;
@@ -220,7 +221,7 @@ public final class QuantityDimension implements Dimension, Serializable {
    * @since 1.0
    */
   public Dimension divide(Dimension that) {
-    return this.multiply(that.pow(-1));
+      return that instanceof QuantityDimension ? this.divide((QuantityDimension) that) : this.divide(that);
   }
 
   /**
@@ -232,7 +233,7 @@ public final class QuantityDimension implements Dimension, Serializable {
    * @since 1.0
    */
   public QuantityDimension divide(QuantityDimension that) {
-    return this.multiply(that.pow(-1));
+    return new QuantityDimension(ProductUnit.ofQuotient(pseudoUnit, that.pseudoUnit));
   }
 
   /**

--- a/src/test/java/tech/units/indriya/quantity/QuantityDimensionTest.java
+++ b/src/test/java/tech/units/indriya/quantity/QuantityDimensionTest.java
@@ -96,6 +96,28 @@ public class QuantityDimensionTest {
   }
 
   /**
+   * Verifies that the division is done correctly on powered units. Relies on the toString method to
+   * verify the result.
+   */
+  @Test
+  public void divisionIsDoneCorrectlyOnPoweredBaseUnits() {
+    Dimension m2 = QuantityDimension.MASS.pow(2);
+    Dimension result = QuantityDimension.LENGTH.divide(m2);
+    assertEquals("[L]/[M]²", result.toString());
+  }
+
+  /**
+   * Verifies that the division is done correctly on powered units. Relies on the toString method to
+   * verify the result.
+   */
+  @Test
+  public void divisionIsDoneCorrectlyOnPoweredProductUnits() {
+    Dimension ml = QuantityDimension.MASS.multiply(QuantityDimension.LENGTH);
+    Dimension result = QuantityDimension.LENGTH.divide(ml);
+    assertEquals("1/[M]", result.toString());
+  }
+
+  /**
    * Verifies that raising to a power is done correctly by checking that multiplication with itself is the same as raising to the power of two.
    */
   @Test


### PR DESCRIPTION
That is basically a follow up on #124, where the following tests would fail:
```
Dimension m2 = QuantityDimension.MASS.pow(2);
Dimension result = QuantityDimension.LENGTH.divide(m2);
assertEquals("[L]/[M]²", result.toString()); // <= returns "[L]/null" instead
```
```
Dimension ml = QuantityDimension.MASS.multiply(QuantityDimension.LENGTH);
Dimension result = QuantityDimension.LENGTH.divide(ml);
assertEquals("1/[M]", result.toString()); // <= returns "[L]/null" instead
```

This is due to `divide(Dimension dim)` calling `multiply(dim.pow(-1))` which has changed behaviour after #129

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/indriya/135)
<!-- Reviewable:end -->
