### PR TITLE
Introduces UnitFormatRountripTest, to test any UnitFormat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,12 @@
 		</dependency>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+			<version>${junit.jupiter.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-engine</artifactId>
 			<version>${junit.jupiter.version}</version>
 			<scope>test</scope>

--- a/src/test/java/tech/units/indriya/format/FormatTestingUtil.java
+++ b/src/test/java/tech/units/indriya/format/FormatTestingUtil.java
@@ -1,0 +1,137 @@
+/*
+ * Units of Measurement Reference Implementation
+ * Copyright (c) 2005-2018, Jean-Marie Dautelle, Werner Keil, Otavio Santana.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of JSR-385, Indriya nor the names of their contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package tech.units.indriya.format;
+
+import javax.measure.MetricPrefix;
+import javax.measure.Prefix;
+import javax.measure.Unit;
+import javax.measure.format.UnitFormat;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static tech.units.indriya.unit.Units.*;
+
+/**
+ * package private utility class to consolidate format testing idioms 
+ *   
+ * @author Andi Huber
+ */
+class FormatTestingUtil {
+    
+    /**
+     * Complete set of built-in non-prefixed Units.
+     */
+    static enum NonPrefixedUnits {
+
+        Ampere(AMPERE),
+        Candela(CANDELA),
+        Kelvin(KELVIN),
+        Metre(METRE),
+        Mole(MOLE),
+        Second(SECOND),
+        Gram(GRAM),
+        Radian(RADIAN),
+        Steradian(STERADIAN),
+        Hertz(HERTZ),
+        Newton(NEWTON),
+        Pascal(PASCAL),
+        Joule(JOULE),
+        Watt(WATT),
+        Coulomb(COULOMB),
+        Volt(VOLT),
+        Farad(FARAD),
+        Ohm(OHM),
+        Siemens(SIEMENS),
+        Weber(WEBER),
+        Tesla(TESLA),
+        Henry(HENRY),
+        Celsius(CELSIUS),
+        Lumen(LUMEN),
+        Lux(LUX),
+        Becquerel(BECQUEREL),
+        Gray(GRAY),
+        Sievert(SIEVERT),
+        Katal(KATAL),
+        //SQUARE_METRE
+        //CUBIC_METRE
+        //PERCENT
+        //MINUTE
+        //HOUR
+        //DAY
+        //WEEK
+        //YEAR
+        Litre(LITRE)
+        
+        ;
+        
+        final Unit<?> unit;
+        final String unitLiteral;
+        final String onFailureMsg = String.format("testing %s", this.name());
+        
+        private NonPrefixedUnits(Unit<?> unit) {
+            this.unit = unit;
+            this.unitLiteral = unit.getSymbol();
+        }
+        
+        void roundtrip(final UnitFormat format) {
+            
+            test(format);
+                        
+            for(Prefix prefix : MetricPrefix.values()) {
+                test(format, prefix);
+            }
+            
+        }
+        
+        private void test(final UnitFormat format) {
+            
+            // parsing
+            assertEquals(unit, format.parse(unitLiteral), onFailureMsg);
+            
+            // formatting
+            assertEquals(unitLiteral, format.format(unit), onFailureMsg);
+        }
+        
+        private void test(final UnitFormat format, Prefix prefix) {
+            
+            final Unit<?> prefixedUnit = unit.prefix(prefix);
+            final String prefixedUnitLiteral = prefix.getSymbol()+unitLiteral;
+            
+            // parsing
+            assertEquals(prefixedUnit, format.parse(prefixedUnitLiteral), onFailureMsg);
+            
+            // formatting
+            assertEquals(prefixedUnitLiteral, format.format(prefixedUnit), onFailureMsg);
+            
+        }
+       
+    }
+    
+
+}

--- a/src/test/java/tech/units/indriya/format/UnitFormatRountripTest.java
+++ b/src/test/java/tech/units/indriya/format/UnitFormatRountripTest.java
@@ -1,0 +1,110 @@
+/*
+ * Units of Measurement Reference Implementation
+ * Copyright (c) 2005-2018, Jean-Marie Dautelle, Werner Keil, Otavio Santana.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of JSR-385, Indriya nor the names of their contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package tech.units.indriya.format;
+
+import javax.measure.format.UnitFormat;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import tech.units.indriya.format.FormatTestingUtil.NonPrefixedUnits;
+
+/**
+ * Testing (almost) all built-in units and their prefixed variants
+ * against different {@link UnitFormat} instances. 
+ * 
+ * @author Andi Huber
+ */
+class UnitFormatRountripTest {
+	
+	@BeforeEach
+	public void init() {
+
+	}
+	
+	@Nested
+    @DisplayName("EBNFUnitFormat") @Disabled("yet too many errors")
+    public class EBNFUnitFormatTest {
+	    
+	    UnitFormat format = EBNFUnitFormat.getInstance();
+
+        /**
+         * We cycle through all {@code FormatTestingUtil.NonPrefixedUnits} and 
+         * for each such candidate test, whether parsing and formating are 
+         * consistent with expected behavior.
+         */
+	    @ParameterizedTest(name = "{index} => unit=''{0}''")
+        @DisplayName("should parse and format as expected")
+        @EnumSource(NonPrefixedUnits.class)
+        public void formatingAndParsing(NonPrefixedUnits testCandidate) {
+	        testCandidate.roundtrip(format);
+        }       
+
+    }
+	
+	@Nested
+    @DisplayName("SimpleUnitFormat")
+    public class SimpleUnitFormatTest {
+        
+        UnitFormat format = SimpleUnitFormat.getInstance();
+
+        /**
+         * We cycle through all {@code FormatTestingUtil.NonPrefixedUnits} and 
+         * for each such candidate test, whether parsing and formating are 
+         * consistent with expected behavior.
+         */
+        @ParameterizedTest(name = "{index} => unit=''{0}''")
+        @DisplayName("should parse and format as expected")
+        @EnumSource(NonPrefixedUnits.class)
+        public void formatingAndParsing(NonPrefixedUnits testCandidate) {
+            
+            //TODO roundtrips currently fail for Gram, Celsius and Litre
+            if(testCandidate == NonPrefixedUnits.Gram
+                    || testCandidate == NonPrefixedUnits.Celsius
+                    || testCandidate == NonPrefixedUnits.Litre) {
+                
+                System.err.println(String.format("WARNING: ommiting test-candidate: %s in %s",
+                        testCandidate.name(),
+                        this.getClass().getName()));
+                return;
+            }
+            
+            testCandidate.roundtrip(format);
+            
+        }       
+
+    }
+
+	
+}


### PR DESCRIPTION
also disabling tests that fail yet
also add junit-jupiter-params to pom.xml (test-scope)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/indriya/153)
<!-- Reviewable:end -->
