### PR TITLE
UnitFormatRoundtripTest: completing the roundtrip ...

### DIFF
--- a/src/test/java/tech/units/indriya/format/UnitFormatRoundtripTest.java
+++ b/src/test/java/tech/units/indriya/format/UnitFormatRoundtripTest.java
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 
-import tech.units.indriya.format.FormatTestingUtil.NonPrefixedUnits;
+import tech.units.indriya.format.UnitFormatRoundtripUtil.NonPrefixedUnits;
 
 /**
  * Testing (almost) all built-in units and their prefixed variants
@@ -45,7 +45,7 @@ import tech.units.indriya.format.FormatTestingUtil.NonPrefixedUnits;
  * 
  * @author Andi Huber
  */
-class UnitFormatRountripTest {
+class UnitFormatRoundtripTest {
 	
 	@Nested
     @DisplayName("EBNFUnitFormat") @Disabled("yet too many errors")


### PR DESCRIPTION
By roundtrip we mean for following assertion to hold:

`format(unit) === format(parse(format(unit)))`

also fixing typo and adding some comments/java-doc

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/indriya/156)
<!-- Reviewable:end -->
