### PR TITLE
Equal speeds with the same units are not equal

### DIFF
--- a/src/test/java/tech/units/indriya/quantity/QuantitiesTest.java
+++ b/src/test/java/tech/units/indriya/quantity/QuantitiesTest.java
@@ -29,28 +29,20 @@
  */
 package tech.units.indriya.quantity;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static tech.units.indriya.unit.Units.CELSIUS;
-import static tech.units.indriya.unit.Units.PASCAL;
-import static javax.measure.LevelOfMeasurement.INTERVAL;
+import org.junit.jupiter.api.Test;
+import tech.units.indriya.ComparableQuantity;
+import tech.units.indriya.unit.Units;
 
+import javax.measure.Quantity;
+import javax.measure.quantity.*;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.math.RoundingMode;
 
-import javax.measure.Quantity;
-import javax.measure.quantity.Pressure;
-import javax.measure.quantity.Temperature;
-import javax.measure.quantity.Time;
-
-import org.junit.jupiter.api.Test;
-
-import tech.units.indriya.quantity.DecimalQuantity;
-import tech.units.indriya.quantity.DoubleQuantity;
-import tech.units.indriya.quantity.NumberQuantity;
-import tech.units.indriya.quantity.Quantities;
-import tech.units.indriya.unit.Units;
+import static javax.measure.LevelOfMeasurement.INTERVAL;
+import static org.junit.jupiter.api.Assertions.*;
+import static tech.units.indriya.unit.Units.CELSIUS;
+import static tech.units.indriya.unit.Units.PASCAL;
 
 /**
  *
@@ -144,5 +136,12 @@ public class QuantitiesTest {
     value.setScale(4, RoundingMode.HALF_EVEN);
     BigDecimal expected = BigDecimal.valueOf(31556952);
     assertEquals(expected.setScale(4, RoundingMode.HALF_EVEN), value.setScale(4, RoundingMode.HALF_EVEN));
+  }
+
+  @Test
+  public void equalityValuesTest() {
+   ComparableQuantity<Speed> shouldBe = Quantities.getQuantity(15.0, Units.KILOMETRE_PER_HOUR);
+   ComparableQuantity<Speed> parsedSpeed = (ComparableQuantity<Speed>) Quantities.getQuantity("15.0 km/h");
+   assertEquals(shouldBe, parsedSpeed);
   }
 }


### PR DESCRIPTION
Hi, the following test will fail.
The problem lies in [AbstractUnit, line 606](https://github.com/unitsofmeasurement/indriya/blob/e58feee4b900447b7adbef24817ee9c8f968dd3c/src/main/java/tech/units/indriya/AbstractUnit.java#L606).
However, I was not able to make a quick fix due to cyclic usage in [BaseUnit, line 151](https://github.com/unitsofmeasurement/indriya/blob/e58feee4b900447b7adbef24817ee9c8f968dd3c/src/main/java/tech/units/indriya/unit/BaseUnit.java#L151), so only this PR with test.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/indriya/157)
<!-- Reviewable:end -->
