### PR TITLE
Makes MultiplyConverter an interface and hides its implementers

### DIFF
--- a/src/main/java/tech/units/indriya/AbstractConverter.java
+++ b/src/main/java/tech/units/indriya/AbstractConverter.java
@@ -37,11 +37,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
 
-import javax.measure.Prefix;
 import javax.measure.UnitConverter;
 
 import tech.units.indriya.function.ConverterCompositionHandler;
-import tech.units.indriya.function.PowerOfIntConverter;
 import tech.uom.lib.common.function.Converter;
 import tech.uom.lib.common.util.UnitComparator;
 
@@ -87,16 +85,6 @@ public abstract class AbstractConverter
 	 * DefaultQuantityFactory constructor.
 	 */
 	protected AbstractConverter() {
-	}
-
-	/**
-	 * Creates a converter with the specified Prefix.
-	 * 
-	 * @param prefix
-	 *            the prefix for the factor.
-	 */
-	public static UnitConverter of(Prefix prefix) {
-		return PowerOfIntConverter.of(prefix);
 	}
 
 	@Override

--- a/src/main/java/tech/units/indriya/format/AbstractUnitFormat.java
+++ b/src/main/java/tech/units/indriya/format/AbstractUnitFormat.java
@@ -90,7 +90,9 @@ public abstract class AbstractUnitFormat implements UnitFormat {
    *              if the Format cannot format the given object
    */
   public final String format(Unit<?> unit) {
-    if (unit instanceof AbstractUnit) return format((AbstractUnit<?>) unit, new StringBuilder()).toString();
+    if (unit instanceof AbstractUnit) {
+      return format((AbstractUnit<?>) unit, new StringBuilder()).toString();
+    }
 
     try {
       return (this.format(unit, new StringBuilder())).toString();

--- a/src/main/java/tech/units/indriya/format/SimpleUnitFormat.java
+++ b/src/main/java/tech/units/indriya/format/SimpleUnitFormat.java
@@ -52,8 +52,7 @@ import javax.measure.format.UnitFormat;
 import tech.units.indriya.AbstractUnit;
 import tech.units.indriya.function.AddConverter;
 import tech.units.indriya.function.MultiplyConverter;
-import tech.units.indriya.function.PowerOfIntConverter;
-import tech.units.indriya.function.RationalConverter;
+import tech.units.indriya.function.RationalNumber;
 import tech.units.indriya.unit.AlternateUnit;
 import tech.units.indriya.unit.AnnotatedUnit;
 import tech.units.indriya.unit.BaseUnit;
@@ -113,7 +112,7 @@ public abstract class SimpleUnitFormat extends AbstractUnitFormat {
   // TODO try to consolidate those
   private static final UnitConverter[] METRIC_PREFIX_CONVERTERS =  
 		  Stream.of(MetricPrefix.values())
-		  .map(PowerOfIntConverter::of)
+		  .map(MultiplyConverter::ofPrefix)
 		  .collect(Collectors.toList())
   		  .toArray(new UnitConverter[] {});
   
@@ -125,7 +124,7 @@ public abstract class SimpleUnitFormat extends AbstractUnitFormat {
   
   private static final UnitConverter[] BINARY_PREFIX_CONVERTERS =  
           Stream.of(BinaryPrefix.values())
-          .map(PowerOfIntConverter::of)
+          .map(MultiplyConverter::ofPrefix)
           .collect(Collectors.toList())
           .toArray(new UnitConverter[] {});
 
@@ -405,20 +404,25 @@ public abstract class SimpleUnitFormat extends AbstractUnitFormat {
           if (cvtr instanceof AddConverter) {
             result.append('+');
             result.append(((AddConverter) cvtr).getOffset());
-          } else if (cvtr instanceof RationalConverter) {
-            double dividend = ((RationalConverter) cvtr).getDividend().doubleValue();
-            if (dividend != 1) {
-              result.append('*');
-              result.append(dividend);
-            }
-            double divisor = ((RationalConverter) cvtr).getDivisor().doubleValue();
-            if (divisor != 1) {
-              result.append('/');
-              result.append(divisor);
-            }
           } else if (cvtr instanceof MultiplyConverter) {
-            result.append('*');
-            result.append(((MultiplyConverter) cvtr).getFactor());
+            Number scaleFactor = ((MultiplyConverter) cvtr).getScaleFactor();
+            if(scaleFactor instanceof RationalNumber) {
+                
+                RationalNumber rational = (RationalNumber)scaleFactor;
+                RationalNumber reciprocal = rational.reciprocal();
+                if(reciprocal.isInteger()) {
+                    result.append('/');
+                    result.append(reciprocal.toString()); // renders as integer
+                } else {
+                    result.append('*');
+                    result.append(scaleFactor);  
+                }
+                
+            } else {
+                result.append('*');
+                result.append(scaleFactor);
+            }
+            
           } else { // Other converters.
             return "[" + baseUnit + "?]";
           }

--- a/src/main/java/tech/units/indriya/format/SymbolMap.java
+++ b/src/main/java/tech/units/indriya/format/SymbolMap.java
@@ -182,7 +182,7 @@ public final class SymbolMap {
   public void label(Prefix prefix, String symbol) {
     symbolToPrefix.put(symbol, prefix);
     prefixToSymbol.put(prefix, symbol);
-    converterToPrefix.put(MultiplyConverter.of(prefix), prefix);
+    converterToPrefix.put(MultiplyConverter.ofPrefix(prefix), prefix);
   }
 
   /**

--- a/src/main/java/tech/units/indriya/function/Calculus.java
+++ b/src/main/java/tech/units/indriya/function/Calculus.java
@@ -33,6 +33,7 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import java.math.RoundingMode;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -41,6 +42,7 @@ import java.util.ServiceLoader;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import tech.units.indriya.AbstractConverter;
 import tech.units.indriya.spi.NumberSystem;
 
 /**
@@ -48,7 +50,7 @@ import tech.units.indriya.spi.NumberSystem;
  * 
  * @author Andi Huber
  * @author Werner Keil
- * @version 1.2, June 10, 2019
+ * @version 1.3, June 21, 2019
  * @since 2.0
  */
 public final class Calculus {
@@ -189,4 +191,27 @@ public final class Calculus {
 			return sum;
 		}
 	}
+	
+	// -- NORMAL FORM TABLE OF COMPOSITION
+	
+	private final static Map<Class<? extends AbstractConverter>, Integer> normalFormOrder = new HashMap<>(9);
+
+    public static Map<Class<? extends AbstractConverter>, Integer> getNormalFormOrder() {
+        synchronized (normalFormOrder) {
+            if(normalFormOrder.isEmpty()) {
+                normalFormOrder.put(AbstractConverter.IDENTITY.getClass(), 0);
+                normalFormOrder.put(PowerOfIntConverter.class, 1); 
+                normalFormOrder.put(RationalConverter.class, 2); 
+                normalFormOrder.put(PowerOfPiConverter.class, 3);
+                normalFormOrder.put(DoubleMultiplyConverter.class, 4);
+                normalFormOrder.put(AddConverter.class, 5);
+                normalFormOrder.put(LogConverter.class, 6); 
+                normalFormOrder.put(ExpConverter.class, 7);
+                normalFormOrder.put(AbstractConverter.Pair.class, 99);        
+            }
+        }
+        
+        return Collections.unmodifiableMap(normalFormOrder);
+    }
+	
 }

--- a/src/main/java/tech/units/indriya/function/DoubleMultiplyConverter.java
+++ b/src/main/java/tech/units/indriya/function/DoubleMultiplyConverter.java
@@ -1,0 +1,155 @@
+/*
+ * Units of Measurement Reference Implementation
+ * Copyright (c) 2005-2019, Units of Measurement project.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of JSR-385, Indriya nor the names of their contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package tech.units.indriya.function;
+
+import java.util.Objects;
+
+import javax.measure.UnitConverter;
+
+import tech.units.indriya.AbstractConverter;
+import tech.units.indriya.internal.function.calc.Calculator;
+import tech.uom.lib.common.function.DoubleFactorSupplier;
+
+/**
+ * <p>
+ * This class represents a converter multiplying numeric values by a constant
+ * scaling factor (<code>double</code> based).
+ * </p>
+ * 
+ * @author <a href="mailto:jean-marie@dautelle.com">Jean-Marie Dautelle</a>
+ * @author <a href="mailto:units@catmedia.us">Werner Keil</a>
+ * @author Andi Huber
+ * @version 1.3, Jun 21, 2019
+ * @since 1.0
+ */
+final class DoubleMultiplyConverter 
+extends AbstractConverter 
+implements MultiplyConverter, DoubleFactorSupplier {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 6588759878444545649L;
+
+	/**
+	 * Holds the scale factor.
+	 */
+	private final double doubleFactor;
+
+	/**
+	 * Creates a multiply converter with the specified scale factor.
+	 * 
+	 * @param factor
+	 *            the scaling factor.
+	 */
+	private DoubleMultiplyConverter(double factor) {
+		this.doubleFactor = factor;
+	}
+
+	/**
+	 * Creates a multiply converter with the specified scale factor.
+	 * 
+	 * @param factor
+	 *            the scaling factor.
+	 */
+	static DoubleMultiplyConverter of(double factor) {
+		return new DoubleMultiplyConverter(factor);
+	}
+
+	@Override
+	public double getFactor() {
+		return doubleFactor;
+	}
+
+	@Override
+	public boolean isIdentity() {
+		return doubleFactor == 1.0;
+	}
+
+	@Override
+	protected boolean canReduceWith(AbstractConverter that) {
+		return that instanceof DoubleMultiplyConverter;
+	}
+
+	@Override
+	protected AbstractConverter reduce(AbstractConverter that) {
+		return new DoubleMultiplyConverter(doubleFactor * ((DoubleMultiplyConverter) that).doubleFactor);
+	}
+
+	@Override
+	public DoubleMultiplyConverter inverseWhenNotIdentity() {
+		return new DoubleMultiplyConverter(1.0 / doubleFactor);
+	}
+
+    @Override
+    protected Number convertWhenNotIdentity(Number value) {
+        return Calculator.of(doubleFactor)
+              .multiply(value)
+              .peek();
+    }
+	
+	@Override
+	public final String transformationLiteral() {
+		return String.format("x -> x * %s", doubleFactor);
+	}
+
+	@Override
+	public boolean equals(Object obj) {
+		if (this == obj) {
+			return true;
+		}
+		if (obj instanceof DoubleMultiplyConverter) {
+		    DoubleMultiplyConverter that = (DoubleMultiplyConverter) obj;
+			return Objects.equals(doubleFactor, that.doubleFactor);
+		}
+		return false;
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hashCode(doubleFactor);
+	}
+
+	@Override
+	public Double getValue() {
+		return doubleFactor;
+	}
+
+	@Override
+	public int compareTo(UnitConverter o) {
+		if (this == o) {
+			return 0;
+		}
+		if (o instanceof DoubleMultiplyConverter) {
+			return getValue().compareTo(((DoubleMultiplyConverter) o).getValue());
+		}
+		return -1;
+	}
+}

--- a/src/main/java/tech/units/indriya/function/IdentityMultiplyConverter.java
+++ b/src/main/java/tech/units/indriya/function/IdentityMultiplyConverter.java
@@ -29,63 +29,65 @@
  */
 package tech.units.indriya.function;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import java.util.Collections;
+import java.util.List;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import javax.measure.UnitConverter;
 
-public class MultiplyConverterTest {
+import tech.units.indriya.AbstractConverter;
 
-  private MultiplyConverter converter;
+/**
+ * @author Andi Huber
+ * @since 2.0
+ */
+final class IdentityMultiplyConverter implements MultiplyConverter {
 
-  @BeforeEach
-  public void setUp() throws Exception {
-    converter = new MultiplyConverter(2);
-  }
+    private static final long serialVersionUID = 1L;
+    
+    public final static IdentityMultiplyConverter INSTANCE = new IdentityMultiplyConverter();
 
-  @Test
-  public void testConvertMethod() {
-    assertEquals(200, converter.convert(100), 0.1);
-    assertEquals(0, converter.convert(0));
-    assertEquals(-200, converter.convert(-100), 0.1);
-  }
+    private IdentityMultiplyConverter() {
+        // hidden
+    }
+    
+    @Override
+    public boolean isIdentity() {
+        return true;
+    }
 
-  @Test
-  public void testEqualityOfTwoLogConverter() {
-    assertNotNull(converter);
-    assertEquals(new MultiplyConverter(2), converter);
-  }
+    @Override
+    public UnitConverter inverse() {
+        return this;
+    }
 
-  @Test
-  public void testGetValuePiDivisorConverter() {
-    assertEquals(Double.valueOf(2d), converter.getValue());
-  }
+    @Override
+    public Number convert(Number value) {
+        return value;
+    }
 
-  @Test
-  public void isLinearOfLogConverterTest() {
-    assertTrue(converter.isLinear());
-  }
+    @Override
+    public double convert(double value) {
+        return value;
+    }
 
-  @Test
-  public void inverseTest() {
-    assertNotNull(converter.inverse());
-    assertEquals(new MultiplyConverter(0.5), converter.inverse());
-  }
+    @Override
+    public UnitConverter concatenate(UnitConverter converter) {
+        return converter;
+    }
 
-  @Test
-  public void identityTest() {
-	  assertTrue(new MultiplyConverter(1).isIdentity());
-  }
+    @Override
+    public List<? extends UnitConverter> getConversionSteps() {
+        return Collections.emptyList();
+    }
 
-  @Test
-  public void valueTest() {
-    assertEquals(Double.valueOf(2), converter.getValue());
-  }
+    @Override
+    public Number getValue() {
+        return 1;
+    }
 
-  @Test
-  public void toStringTest() {
-    assertEquals("Multiply(x -> x * 2.0)", converter.toString());
-  }
+    @Override
+    public int compareTo(UnitConverter o) {
+        return AbstractConverter.IDENTITY.compareTo(o);
+    }
+
 }

--- a/src/main/java/tech/units/indriya/function/MixedRadix.java
+++ b/src/main/java/tech/units/indriya/function/MixedRadix.java
@@ -285,7 +285,7 @@ public class MixedRadix<Q extends Quantity<Q>> {
 	}
 
 	private Radix toRadix(UnitConverter converter) {
-		return new Radix.UnitConverterRadix(converter);
+		return Radix.ofMultiplyConverter(converter);
 	}
 
 	private MixedRadix<Q> append(PrimaryUnitPickState state, Unit<Q> mixedRadixUnit) {

--- a/src/main/java/tech/units/indriya/function/MultiplyConverter.java
+++ b/src/main/java/tech/units/indriya/function/MultiplyConverter.java
@@ -211,24 +211,6 @@ Serializable, Comparable<UnitConverter> {
     default Number getScaleFactor() {
         return getValue();
     }
-
-    // -- PREDICATES FOR RI INTERNAL USE ONLY
-    
-    public static boolean isRational(UnitConverter converter) {
-        return (converter instanceof RationalConverter);
-    }
-    
-    public static boolean isDouble(UnitConverter converter) {
-        return (converter instanceof DoubleMultiplyConverter);
-    }
-    
-    public static boolean isPowerOfPi(UnitConverter converter) {
-        return (converter instanceof PowerOfPiConverter);
-    }
-    
-    public static boolean isPowerOfInt(UnitConverter converter) {
-        return (converter instanceof PowerOfIntConverter);
-    }
     
 
 }

--- a/src/main/java/tech/units/indriya/function/MultiplyConverter.java
+++ b/src/main/java/tech/units/indriya/function/MultiplyConverter.java
@@ -29,135 +29,206 @@
  */
 package tech.units.indriya.function;
 
-import java.util.Objects;
+import java.io.Serializable;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.function.Supplier;
 
+import javax.measure.Prefix;
 import javax.measure.UnitConverter;
 
-import tech.units.indriya.AbstractConverter;
-import tech.units.indriya.internal.function.calc.Calculator;
-import tech.uom.lib.common.function.DoubleFactorSupplier;
+import tech.units.indriya.internal.function.calc.DefaultNumberSystem;
+import tech.units.indriya.spi.NumberSystem;
+import tech.uom.lib.common.function.Converter;
 import tech.uom.lib.common.function.ValueSupplier;
 
 /**
  * <p>
  * This class represents a converter multiplying numeric values by a constant
- * scaling factor (<code>double</code> based).
+ * scaling factor represented by the {@link Number} type.
  * </p>
  * 
- * @author <a href="mailto:jean-marie@dautelle.com">Jean-Marie Dautelle</a>
- * @author <a href="mailto:units@catmedia.us">Werner Keil</a>
  * @author Andi Huber
- * @version 1.2, Jun 3, 2019
- * @since 1.0
+ * @since 2.0
  */
-public final class MultiplyConverter extends AbstractConverter implements ValueSupplier<Double>, DoubleFactorSupplier {
+public interface MultiplyConverter 
+extends UnitConverter, Converter<Number, Number>, ValueSupplier<Number>, Supplier<Number>,
+Serializable, Comparable<UnitConverter> {
+    
+    // -- FACTORIES
+    
+    /**
+     * Creates a MultiplyConverter with the specified constant rational factor.
+     * 
+     * @param factor
+     */
+    public static MultiplyConverter ofRational(RationalNumber factor) {
+        if(factor.equals(RationalNumber.ONE)) {
+            return identity();
+        }
+        return RationalConverter.of(factor);
+    }
+    
+    /**
+     * Creates a MultiplyConverter with the specified rational factor made up 
+     * of {@code dividend} and {@code divisor}
+     * 
+     * @param dividend
+     * @param divisor
+     */
+    public static MultiplyConverter ofRational(long dividend, long divisor) {
+        RationalNumber rational = RationalNumber.of(dividend, divisor); 
+        return ofRational(rational);
+    }
+    
+    /**
+     * Creates a MultiplyConverter with the specified rational factor made up 
+     * of {@code dividend} and {@code divisor}
+     * 
+     * @param dividend
+     * @param divisor
+     */
+    public static MultiplyConverter ofRational(BigInteger dividend, BigInteger divisor) {
+        RationalNumber rational = RationalNumber.of(dividend, divisor);
+        return ofRational(rational);
+    }
+    
+    /**
+     * Creates a MultiplyConverter with the specified constant factor.
+     * 
+     * @param factor
+     * @return
+     */
+    public static MultiplyConverter ofNumber(Number factor) {
 
-	/**
-	 * 
-	 */
-	private static final long serialVersionUID = 6588759878444545649L;
+        NumberSystem ns = Calculus.currentNumberSystem();
+        
+        if(ns.isOne(factor)) {
+            return identity();
+        }
+        
+        Number narrowedFactor = ns.narrow(factor);
+        
+        if(narrowedFactor instanceof RationalNumber) {
+            return ofRational((RationalNumber)narrowedFactor);
+        }
+        
+        if(ns.isInteger(narrowedFactor)) {
+            if(narrowedFactor instanceof BigInteger) {
+                return ofRational(RationalNumber.ofInteger((BigInteger)narrowedFactor));    
+            }
 
-	/**
-	 * Holds the scale factor.
-	 */
-	private final double factor;
-
-	/**
-	 * Creates a multiply converter with the specified scale factor.
-	 * 
-	 * @param factor
-	 *            the scaling factor.
-	 */
-	public MultiplyConverter(double factor) {
-		this.factor = factor;
-	}
-
-	/**
-	 * Creates a multiply converter with the specified scale factor.
-	 * 
-	 * @param factor
-	 *            the scaling factor.
-	 */
-	public static MultiplyConverter of(double factor) {
-		return new MultiplyConverter(factor);
-	}
-
-	/**
-	 * Returns the scale factor of this converter.
-	 * 
-	 * @return the scale factor.
-	 */
-	public double getFactor() {
-		return factor;
-	}
-
-	@Override
-	public boolean isIdentity() {
-		return factor == 1.0;
-	}
-
-	@Override
-	protected boolean canReduceWith(AbstractConverter that) {
-		return that instanceof MultiplyConverter;
-	}
-
-	@Override
-	protected AbstractConverter reduce(AbstractConverter that) {
-		return new MultiplyConverter(factor * ((MultiplyConverter) that).factor);
-	}
-
-	@Override
-	public MultiplyConverter inverseWhenNotIdentity() {
-		return new MultiplyConverter(1.0 / factor);
-	}
+            // TODO[220] yet only implemented for the default number system, 
+            // any other implementation might behave differently;
+            // could fall back to long, but instead fail early
+            if(!(ns instanceof DefaultNumberSystem)) {
+                throw new UnsupportedOperationException("not yet supported");
+            }
+            
+            return ofRational(RationalNumber.ofInteger(narrowedFactor.longValue()));
+        }
+                
+        if(narrowedFactor instanceof Double || narrowedFactor instanceof Float) {
+            return ofDouble(narrowedFactor.doubleValue());
+        }
+        
+        if(narrowedFactor instanceof BigDecimal) {
+            BigDecimal decimal = (BigDecimal)narrowedFactor;
+            RationalNumber rational = RationalNumber.ofBigDecimal(decimal);
+            return ofRational(rational);
+        }
+                
+        // TODO[220] any other case not supported yet, could fall back to double, but instead fail early
+        throw new UnsupportedOperationException("not yet supported");
+    }
+    
+    /**
+     * Creates a MultiplyConverter with the specified constant factor.
+     * 
+     * @param factor
+     * @return
+     */
+    public static MultiplyConverter ofDouble(double factor) {
+        if(factor==0.d) {
+            return identity();
+        }
+        RationalNumber rational = RationalNumber.ofDouble(factor);
+        return ofRational(rational);
+    }
+    
+    /**
+     * Creates a MultiplyConverter with the specified Prefix.
+     * 
+     * @param prefix
+     *            the prefix for the factor.
+     */
+    public static MultiplyConverter ofPrefix(Prefix prefix) {
+        if(prefix==null) {
+            return identity();
+        }
+        return PowerOfIntConverter.of(prefix);
+    }
+    
+    /**
+     * Creates a MultiplyConverter with the specified exponent.
+     * 
+     * @param exponent
+     *            the exponent for the factor π^exponent.
+     */
+    public static MultiplyConverter ofPiToThePowerOf(int exponent) {
+        if(exponent==0) {
+            return identity();
+        }
+        return PowerOfPiConverter.of(exponent);
+    }
+    
+    /**
+     * Returns the an MultiplyConverter that acts as a 'pass-through'.
+     * 
+     */
+    public static MultiplyConverter identity() {
+        return IdentityMultiplyConverter.INSTANCE;
+    }
+    
+    
+    // -- DEFAULTS
+    
+    @Override
+    default boolean isLinear() {
+        return true;
+    }
 
     @Override
-    protected Number convertWhenNotIdentity(Number value) {
-        return Calculator.of(factor)
-              .multiply(value)
-              .peek();
+    default Number get() {
+        return getValue();
     }
-	
-	@Override
-	public final String transformationLiteral() {
-		return String.format("x -> x * %s", factor);
-	}
+    
+    /**
+     * Returns the scale factor of this converter.
+     * 
+     * @return the scale factor.
+     */
+    default Number getScaleFactor() {
+        return getValue();
+    }
 
-	@Override
-	public boolean equals(Object obj) {
-		if (this == obj) {
-			return true;
-		}
-		if (obj instanceof MultiplyConverter) {
-			MultiplyConverter that = (MultiplyConverter) obj;
-			return Objects.equals(factor, that.factor);
-		}
-		return false;
-	}
+    // -- PREDICATES FOR RI INTERNAL USE ONLY
+    
+    public static boolean isRational(UnitConverter converter) {
+        return (converter instanceof RationalConverter);
+    }
+    
+    public static boolean isDouble(UnitConverter converter) {
+        return (converter instanceof DoubleMultiplyConverter);
+    }
+    
+    public static boolean isPowerOfPi(UnitConverter converter) {
+        return (converter instanceof PowerOfPiConverter);
+    }
+    
+    public static boolean isPowerOfInt(UnitConverter converter) {
+        return (converter instanceof PowerOfIntConverter);
+    }
+    
 
-	@Override
-	public int hashCode() {
-		return Objects.hashCode(factor);
-	}
-
-	@Override
-	public boolean isLinear() {
-		return true;
-	}
-
-	@Override
-	public Double getValue() {
-		return factor;
-	}
-
-	@Override
-	public int compareTo(UnitConverter o) {
-		if (this == o) {
-			return 0;
-		}
-		if (o instanceof MultiplyConverter) {
-			return getValue().compareTo(((MultiplyConverter) o).getValue());
-		}
-		return -1;
-	}
 }

--- a/src/main/java/tech/units/indriya/function/RationalConverter.java
+++ b/src/main/java/tech/units/indriya/function/RationalConverter.java
@@ -32,13 +32,11 @@ package tech.units.indriya.function;
 import java.math.BigInteger;
 import java.util.Objects;
 import java.util.function.DoubleSupplier;
-import java.util.function.Supplier;
 
 import javax.measure.UnitConverter;
 
 import tech.units.indriya.AbstractConverter;
 import tech.units.indriya.internal.function.calc.Calculator;
-import tech.uom.lib.common.function.ValueSupplier;
 
 /**
  * <p>
@@ -49,10 +47,11 @@ import tech.uom.lib.common.function.ValueSupplier;
  * @author <a href="mailto:jean-marie@dautelle.com">Jean-Marie Dautelle</a>
  * @author <a href="mailto:units@catmedia.us">Werner Keil</a>
  * @author Andi Huber
- * @version 1.1, Jun 3, 2019
+ * @version 1.2, Jun 21, 2019
  * @since 1.0
  */
-public final class RationalConverter extends AbstractConverter implements ValueSupplier<Double>, Supplier<Double>, DoubleSupplier {
+final class RationalConverter extends AbstractConverter 
+implements MultiplyConverter, DoubleSupplier {
 
 	/**
      * 
@@ -72,7 +71,7 @@ public final class RationalConverter extends AbstractConverter implements ValueS
      * @throws NullPointerException
      *           if factor is {@code null}
      */
-    public RationalConverter(RationalNumber factor) {
+    RationalConverter(RationalNumber factor) {
         Objects.requireNonNull(factor);
         this.factor = factor;
     }
@@ -89,7 +88,7 @@ public final class RationalConverter extends AbstractConverter implements ValueS
 	 * @throws NullPointerException
 	 *           if dividend is {@code null} or divisor is {@code null}
 	 */
-	public RationalConverter(BigInteger dividend, BigInteger divisor) {
+	RationalConverter(BigInteger dividend, BigInteger divisor) {
 	    factor = RationalNumber.of(dividend, divisor);
 	}
 
@@ -103,7 +102,7 @@ public final class RationalConverter extends AbstractConverter implements ValueS
 	 * @throws IllegalArgumentException
 	 *           if <code>divisor = 0</code>
 	 */
-	public RationalConverter(long dividend, long divisor) {
+	RationalConverter(long dividend, long divisor) {
 	    factor = RationalNumber.of(dividend, divisor);
 	}
 
@@ -115,7 +114,7 @@ public final class RationalConverter extends AbstractConverter implements ValueS
      * @throws NullPointerException
      *           if factor is {@code null}
      */
-    public static RationalConverter of(RationalNumber factor) {
+    static RationalConverter of(RationalNumber factor) {
         return new RationalConverter(factor);
     }
 	
@@ -131,7 +130,7 @@ public final class RationalConverter extends AbstractConverter implements ValueS
      * @throws NullPointerException
      *           if dividend is {@code null} or divisor is {@code null}
 	 */
-	public static RationalConverter of(BigInteger dividend, BigInteger divisor) {
+	static RationalConverter of(BigInteger dividend, BigInteger divisor) {
 		return new RationalConverter(dividend, divisor);
 	}
 
@@ -145,7 +144,7 @@ public final class RationalConverter extends AbstractConverter implements ValueS
 	 * @throws IllegalArgumentException
 	 *           if <code>divisor = 0</code>
 	 */
-	public static RationalConverter of(long dividend, long divisor) {
+	static RationalConverter of(long dividend, long divisor) {
 		return new RationalConverter(dividend, divisor);
 	}
 
@@ -229,23 +228,13 @@ public final class RationalConverter extends AbstractConverter implements ValueS
 	}
 
 	@Override
-	public boolean isLinear() {
-		return true;
-	}
-
-	@Override
-	public Double getValue() {
-		return getAsDouble();
+	public Number getValue() {
+		return factor;
 	}
 
 	@Override
 	public double getAsDouble() {
 		return factor.doubleValue();
-	}
-
-	@Override
-	public Double get() {
-		return getValue();
 	}
 
 	@Override

--- a/src/main/java/tech/units/indriya/function/RationalNumber.java
+++ b/src/main/java/tech/units/indriya/function/RationalNumber.java
@@ -117,19 +117,29 @@ public final class RationalNumber extends Number {
 	 * @param number
 	 */
 	public static RationalNumber ofDouble(double number) {
-	     
 	    final BigDecimal decimalValue = BigDecimal.valueOf(number);
+	    return ofBigDecimal(decimalValue);
+	}
+
+	/**
+	 * Returns a {@code RationalNumber} that represents the given BigDecimal decimalValue.
+	 * 
+	 * @param decimalValue
+	 */
+	public static RationalNumber ofBigDecimal(BigDecimal decimalValue) {
+	    Objects.requireNonNull(decimalValue);
+	    
 	    final int scale = decimalValue.scale();
-	    
-	    if(scale<=0) {
-	        return ofInteger(decimalValue.toBigIntegerExact()); 
-	    }
-	    
-	    final BigInteger dividend = BigDecimal.valueOf(number).unscaledValue();
-	    final BigInteger divisor = BigInteger.TEN.pow(scale);
-	    
+        
+        if(scale<=0) {
+            return ofInteger(decimalValue.toBigIntegerExact()); 
+        }
+        
+        final BigInteger dividend = decimalValue.unscaledValue();
+        final BigInteger divisor = BigInteger.TEN.pow(scale);
+        
         return of(dividend, divisor);
-    }
+	}
 
 	/**
 	 * Returns a {@code RationalNumber} that represents the division
@@ -448,10 +458,11 @@ public final class RationalNumber extends Number {
 	 *
 	 * @param useFractionalRepresentation {@code true} for fractional representation {@code 5÷3}; 
 	 *         {@code false} for decimal {@code 1.66667}.
+	 *         
 	 * @return string with canonical string representation of this
 	 *         {@code RationalNumber}
 	 */
-	private String layoutChars(boolean useFractionalRepresentation) {
+	private String layoutChars(boolean useFractionalRepresentation, char divisionCharacter) {
 		if (signum == 0) {
 			return "0";
 		}
@@ -459,7 +470,7 @@ public final class RationalNumber extends Number {
 			return getDividend().toString(); // already includes the sign
 		}
 		if (useFractionalRepresentation) {
-			return getDividend().toString() + DIVISION_CHARACTER + absDivisor;
+			return getDividend().toString() + divisionCharacter + absDivisor;
 		} else {
 			return String.valueOf(bigDecimalValue());
 		}
@@ -467,7 +478,7 @@ public final class RationalNumber extends Number {
 
 	@Override
 	public String toString() {
-		return layoutChars(false);
+		return layoutChars(false, DIVISION_CHARACTER);
 	}
 
 	/**
@@ -479,8 +490,21 @@ public final class RationalNumber extends Number {
 	 * @since 2.0
 	 */
 	public String toRationalString() {
-		return layoutChars(true);
+		return layoutChars(true, DIVISION_CHARACTER);
 	}
+	
+	/**
+     * Returns a string representation of this {@code RationalNumber}, using
+     * fractional notation, eg. {@code 5÷3} or {@code -5÷3}.
+     * 
+     * @param divisionCharacter the character to use instead of the default {@code ÷}
+     * @return string representation of this {@code RationalNumber}, using
+     *         fractional notation.
+     * @since 2.0
+     */
+	public String toRationalString(char divisionCharacter) {
+	    return layoutChars(true, divisionCharacter);
+    }
 
 	@Override
 	public int hashCode() {

--- a/src/main/java/tech/units/indriya/function/RationalNumber.java
+++ b/src/main/java/tech/units/indriya/function/RationalNumber.java
@@ -109,6 +109,27 @@ public final class RationalNumber extends Number {
 	public static RationalNumber of(long dividend, long divisor) {
 		return of(BigInteger.valueOf(dividend), BigInteger.valueOf(divisor));
 	}
+	
+	/**
+     * Returns a {@code RationalNumber} that represents the given double precision 
+     * {@code number}, with an accuracy equivalent to {@link BigDecimal#valueOf(double)}.
+     * 
+	 * @param number
+	 */
+	public static RationalNumber ofDouble(double number) {
+	     
+	    final BigDecimal decimalValue = BigDecimal.valueOf(number);
+	    final int scale = decimalValue.scale();
+	    
+	    if(scale<=0) {
+	        return ofInteger(decimalValue.toBigIntegerExact()); 
+	    }
+	    
+	    final BigInteger dividend = BigDecimal.valueOf(number).unscaledValue();
+	    final BigInteger divisor = BigInteger.TEN.pow(scale);
+	    
+        return of(dividend, divisor);
+    }
 
 	/**
 	 * Returns a {@code RationalNumber} that represents the division
@@ -451,13 +472,13 @@ public final class RationalNumber extends Number {
 
 	/**
 	 * Returns a string representation of this {@code RationalNumber}, using
-	 * fractional notation, eg. {@code 5÷3}.
+	 * fractional notation, eg. {@code 5÷3} or {@code -5÷3}.
 	 *
 	 * @return string representation of this {@code RationalNumber}, using
 	 *         fractional notation.
 	 * @since 2.0
 	 */
-	public String toFractionalString() {
+	public String toRationalString() {
 		return layoutChars(true);
 	}
 

--- a/src/main/java/tech/units/indriya/internal/format/UnitFormatParser.java
+++ b/src/main/java/tech/units/indriya/internal/format/UnitFormatParser.java
@@ -300,7 +300,7 @@ public final class UnitFormatParser implements UnitTokenConstants {
             if (unit != null) {
               {
                 if (true)
-                  return unit.transform(MultiplyConverter.of(prefix)); // TODO try unit.multiply(factor)
+                  return unit.transform(MultiplyConverter.ofPrefix(prefix)); // TODO try unit.multiply(factor)
               }
             }
           }

--- a/src/main/java/tech/units/indriya/internal/function/calc/DefaultNumberSystem.java
+++ b/src/main/java/tech/units/indriya/internal/function/calc/DefaultNumberSystem.java
@@ -243,16 +243,16 @@ public class DefaultNumberSystem implements NumberSystem {
             return RationalNumber.of(BigInteger.ONE, integerToBigInteger(number));
         }
         if(number instanceof BigDecimal) {
-            return BigDecimal.ONE.divide(((BigDecimal) number), Calculus.MATH_CONTEXT);
+            return RationalNumber.ofBigDecimal((BigDecimal) number).reciprocal();
         }
         if(number instanceof RationalNumber) {
             return ((RationalNumber) number).reciprocal();
         }
         if(number instanceof Double) {
-            return BigDecimal.ONE.divide(BigDecimal.valueOf((double)number), Calculus.MATH_CONTEXT);
+            return RationalNumber.ofDouble((double)number).reciprocal();
         }
         if(number instanceof Float) {
-            return BigDecimal.ONE.divide(BigDecimal.valueOf(number.doubleValue()), Calculus.MATH_CONTEXT);
+            return RationalNumber.ofDouble(number.doubleValue()).reciprocal();
         }
         throw unsupportedNumberType(number);
     }

--- a/src/main/java/tech/units/indriya/internal/function/radix/Radix.java
+++ b/src/main/java/tech/units/indriya/internal/function/radix/Radix.java
@@ -59,25 +59,36 @@ public interface Radix {
      */
     Number[] divideAndRemainder(Number number, boolean roundRemainderTowardsZero);
     
-    // -- RADIX IMPLEMENTATION - UnitConverterRadix
-
-    public static class UnitConverterRadix implements Radix {
+    // -- FACTORIES
+    
+    public static Radix ofNumberFactor(Number number) {
+        return new NumberFactorRadix(number);
+    }
+    
+    public static Radix ofMultiplyConverter(UnitConverter linearUnitConverter) {
+        Objects.requireNonNull(linearUnitConverter, "unitConverter cannot be null");
+        if(!linearUnitConverter.isLinear()) {
+            throw new IllegalArgumentException("unitConverter is expected to be linear");
+        }
+        Number radix = Calculus.currentNumberSystem().narrow(linearUnitConverter.convert(1));
+        return new NumberFactorRadix(radix);
+    }
+    
+    // -- RADIX IMPLEMENTATION
+    
+    //can be made private with later java versions 
+    public static class NumberFactorRadix implements Radix {
         
-        private final UnitConverter unitConverter;
         private final Number radix;
         
-        public UnitConverterRadix(UnitConverter unitConverter) {
-            Objects.requireNonNull(unitConverter, "unitConverter cannot be null");
-            if(!unitConverter.isLinear()) {
-                throw new IllegalArgumentException("unitConverter is expected to be linear");
-            }
-            this.unitConverter = unitConverter;
-            this.radix = ns().narrow(unitConverter.convert(1));
+        public NumberFactorRadix(Number radix) {
+            this.radix = ns().narrow(radix);
         }
 
         @Override
         public Number multiply(Number number) {
-            return unitConverter.convert(number);
+            Number result = ns().multiply(radix, ns().narrow(number));
+            return ns().narrow(result);
         }
 
         @Override
@@ -92,7 +103,7 @@ public interface Radix {
             return result;
         }
         
-        private NumberSystem ns() {
+        private static NumberSystem ns() {
             return Calculus.currentNumberSystem();
         }
         

--- a/src/main/java/tech/units/indriya/internal/function/simplify/UnitCompositionHandlerYieldingNormalForm.java
+++ b/src/main/java/tech/units/indriya/internal/function/simplify/UnitCompositionHandlerYieldingNormalForm.java
@@ -29,44 +29,30 @@
  */
 package tech.units.indriya.internal.function.simplify;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiPredicate;
 import java.util.function.BinaryOperator;
 
 import tech.units.indriya.AbstractConverter;
-import tech.units.indriya.function.AddConverter;
-import tech.units.indriya.function.ExpConverter;
-import tech.units.indriya.function.LogConverter;
-import tech.units.indriya.function.MultiplyConverter;
-import tech.units.indriya.function.PowerOfIntConverter;
-import tech.units.indriya.function.PowerOfPiConverter;
-import tech.units.indriya.function.RationalConverter;
+import tech.units.indriya.function.Calculus;
 import tech.units.indriya.function.ConverterCompositionHandler;
+import tech.units.indriya.function.PowerOfIntConverter;
 
 /**
  * UnitCompositionHandler yielding a normal-form.
  * A normal-form is required to decide whether two UnitConverters are equivalent.
  * 
  * @author Andi Huber
- * @version 1.0
+ * @version 1.1
  * @since 2.0
  */
 public class UnitCompositionHandlerYieldingNormalForm implements ConverterCompositionHandler {
 
-  private final Map<Class<?>, Integer> normalFormOrder = new HashMap<>(9);
+  private final Map<Class<? extends AbstractConverter>, Integer> normalFormOrder;
 
   public UnitCompositionHandlerYieldingNormalForm() {
-    normalFormOrder.put(AbstractConverter.IDENTITY.getClass(), 0);
-    normalFormOrder.put(PowerOfIntConverter.class, 1); 
-    normalFormOrder.put(RationalConverter.class, 2); 
-    normalFormOrder.put(PowerOfPiConverter.class, 3);
-    normalFormOrder.put(MultiplyConverter.class, 4);
-    normalFormOrder.put(AddConverter.class, 5);
-    normalFormOrder.put(LogConverter.class, 6); 
-    normalFormOrder.put(ExpConverter.class, 7);
-    normalFormOrder.put(AbstractConverter.Pair.class, 99);
+    normalFormOrder = Calculus.getNormalFormOrder();
   }
 
   @Override

--- a/src/main/java/tech/units/indriya/quantity/time/TimeQuantities.java
+++ b/src/main/java/tech/units/indriya/quantity/time/TimeQuantities.java
@@ -47,7 +47,7 @@ import javax.measure.Quantity;
 import javax.measure.Unit;
 import javax.measure.quantity.Time;
 
-import tech.units.indriya.function.PowerOfIntConverter;
+import tech.units.indriya.function.MultiplyConverter;
 import tech.units.indriya.quantity.Quantities;
 import tech.units.indriya.unit.TransformedUnit;
 import tech.units.indriya.unit.Units;
@@ -55,7 +55,8 @@ import tech.units.indriya.unit.Units;
 /**
  * @author Otavio
  * @author Werner
- * @version 1.0
+ * @author Andi Huber
+ * @version 1.1
  * @since 1.0
  */
 public final class TimeQuantities {
@@ -66,13 +67,13 @@ public final class TimeQuantities {
 	// Convenience constants outside the unit system (multiples are not held there)
 
 	public static final Unit<Time> MICROSECOND = new TransformedUnit<>("μs", SECOND, SECOND,
-			PowerOfIntConverter.of(MetricPrefix.MICRO));
+			MultiplyConverter.ofPrefix(MetricPrefix.MICRO));
 
 	public static final TransformedUnit<Time> MILLISECOND = new TransformedUnit<>("ms", SECOND, SECOND,
-			PowerOfIntConverter.of(MetricPrefix.MILLI));
+	        MultiplyConverter.ofPrefix(MetricPrefix.MILLI));
 
 	public static final TransformedUnit<Time> NANOSECOND = new TransformedUnit<>("ns", SECOND, SECOND,
-			PowerOfIntConverter.of(MetricPrefix.NANO));
+	        MultiplyConverter.ofPrefix(MetricPrefix.NANO));
 
 	/**
 	 * Creates the {@link Quantity<Time>} based in the difference of the two

--- a/src/main/java/tech/units/indriya/unit/Units.java
+++ b/src/main/java/tech/units/indriya/unit/Units.java
@@ -29,12 +29,6 @@
  */
 package tech.units.indriya.unit;
 
-import tech.units.indriya.AbstractSystemOfUnits;
-import tech.units.indriya.AbstractUnit;
-import tech.units.indriya.function.AddConverter;
-import tech.units.indriya.function.RationalConverter;
-import tech.units.indriya.function.RationalNumber;
-import tech.units.indriya.quantity.QuantityDimension;
 import static tech.units.indriya.AbstractUnit.ONE;
 
 import javax.measure.Quantity;
@@ -73,6 +67,13 @@ import javax.measure.quantity.Temperature;
 import javax.measure.quantity.Time;
 import javax.measure.quantity.Volume;
 import javax.measure.spi.SystemOfUnits;
+
+import tech.units.indriya.AbstractSystemOfUnits;
+import tech.units.indriya.AbstractUnit;
+import tech.units.indriya.function.AddConverter;
+import tech.units.indriya.function.MultiplyConverter;
+import tech.units.indriya.function.RationalNumber;
+import tech.units.indriya.quantity.QuantityDimension;
 
 /**
  * <p>
@@ -411,7 +412,7 @@ public class Units extends AbstractSystemOfUnits {
 	/**
 	 * A dimensionless unit accepted for use with SI units (standard name <code>%</code>).
 	 */
-	public static final Unit<Dimensionless> PERCENT = addUnit(new TransformedUnit<>(ONE, new RationalConverter(1, 100)));
+	public static final Unit<Dimensionless> PERCENT = addUnit(new TransformedUnit<>(ONE, MultiplyConverter.ofRational(1, 100)));
 
 	// ////////
 	// Time //
@@ -419,17 +420,17 @@ public class Units extends AbstractSystemOfUnits {
 	/**
 	 * A time unit accepted for use with SI units (standard name <code>min</code>).
 	 */
-	public static final Unit<Time> MINUTE = addUnit(new TransformedUnit<>("min", SECOND, SECOND, new RationalConverter(60, 1)));
+	public static final Unit<Time> MINUTE = addUnit(new TransformedUnit<>("min", SECOND, SECOND, MultiplyConverter.ofRational(60, 1)));
 
 	/**
 	 * A time unit accepted for use with SI units (standard name <code>h</code> ).
 	 */
-	public static final Unit<Time> HOUR = addUnit(new TransformedUnit<>("h", SECOND, SECOND, new RationalConverter(60 * 60, 1)));
+	public static final Unit<Time> HOUR = addUnit(new TransformedUnit<>("h", SECOND, SECOND, MultiplyConverter.ofRational(60 * 60, 1)));
 
 	/**
 	 * A time unit accepted for use with SI units (standard name <code>d</code> ).
 	 */
-	public static final Unit<Time> DAY = addUnit(new TransformedUnit<>("d", SECOND, SECOND, new RationalConverter(24 * 60 * 60, 1)));
+	public static final Unit<Time> DAY = addUnit(new TransformedUnit<>("d", SECOND, SECOND, MultiplyConverter.ofRational(24 * 60 * 60, 1)));
 
 	/**
 	 * A unit of duration equal to 7 {@link #DAY} (standard name <code>week</code>).
@@ -447,7 +448,7 @@ public class Units extends AbstractSystemOfUnits {
 	 * @see <a href="https://en.wikipedia.org/wiki/Litre"> Wikipedia: Litre</a>
 	 */
 	public static final Unit<Volume> LITRE = AbstractSystemOfUnits.Helper.addUnit(INSTANCE.units, new TransformedUnit<Volume>(CUBIC_METRE,
-		new RationalConverter(1, 1000)), "Litre", "l");
+		MultiplyConverter.ofRational(1, 1000)), "Litre", "l");
 
 	/**
 	 * Returns the unique instance of this class.

--- a/src/test/java/tech/units/indriya/AbsUnitTest.java
+++ b/src/test/java/tech/units/indriya/AbsUnitTest.java
@@ -29,14 +29,19 @@
  */
 package tech.units.indriya;
 
+import static javax.measure.MetricPrefix.KILO;
+import static javax.measure.MetricPrefix.MILLI;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static javax.measure.MetricPrefix.*;
-import static tech.units.indriya.unit.Units.*;
+import static tech.units.indriya.unit.Units.CELSIUS;
+import static tech.units.indriya.unit.Units.GRAM;
+import static tech.units.indriya.unit.Units.KILOGRAM;
+import static tech.units.indriya.unit.Units.METRE;
+import static tech.units.indriya.unit.Units.WATT;
 
 import java.math.BigDecimal;
 import java.util.Map;
@@ -52,7 +57,6 @@ import javax.measure.quantity.Power;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
-import tech.units.indriya.AbstractUnit;
 import tech.units.indriya.format.SimpleUnitFormat;
 import tech.units.indriya.quantity.Quantities;
 import tech.units.indriya.unit.BaseUnit;
@@ -306,7 +310,7 @@ public class AbsUnitTest {
 		assertNotNull(result);
 		// assertEquals(METRE, result.getSystemUnit()); TODO they should be equal
 		assertEquals(METRE.toString(), result.getSystemUnit().toString());
-		assertEquals("m/3.0", result.toString());
+		assertEquals("m/3", result.toString());
 	}
 
 	@Test
@@ -315,7 +319,7 @@ public class AbsUnitTest {
 		assertNotNull(result);
 		// assertEquals(METRE, result.getSystemUnit()); TODO they should be equal
 		assertEquals(METRE.toString(), result.getSystemUnit().toString());
-		assertEquals("m/3.0", result.toString());
+		assertEquals("m/3", result.toString());
 	}
 
 	@Test
@@ -332,7 +336,7 @@ public class AbsUnitTest {
 		assertNotNull(result);
 		// assertEquals(METRE, result.getSystemUnit()); TODO they should be equal
 		assertEquals(METRE.toString(), result.getSystemUnit().toString());
-		assertEquals("m*4.0", result.toString());
+		assertEquals("m*4", result.toString());
 	}
 
 	@Test
@@ -341,7 +345,7 @@ public class AbsUnitTest {
 		assertNotNull(result);
 		// assertEquals(METRE, result.getSystemUnit()); TODO they should be equal
 		assertEquals(METRE.toString(), result.getSystemUnit().toString());
-		assertEquals("m*4.0", result.toString());
+		assertEquals("m*4", result.toString());
 	}
 
 	@Test
@@ -358,7 +362,7 @@ public class AbsUnitTest {
 		assertNotNull(result);
 		// assertEquals(METRE, result.getSystemUnit()); TODO they should be equal
 		assertEquals(METRE.toString(), result.getSystemUnit().toString());
-		assertEquals("m+5.0", result.toString());
+		assertEquals("m+5", result.toString());
 	}
 
 	@Test
@@ -367,7 +371,7 @@ public class AbsUnitTest {
 		assertNotNull(result);
 		// assertEquals(METRE, result.getSystemUnit()); TODO they should be equal
 		assertEquals(METRE.toString(), result.getSystemUnit().toString());
-		assertEquals("m+5.0", result.toString());
+		assertEquals("m+5", result.toString());
 	}
 
 	@Test

--- a/src/test/java/tech/units/indriya/format/EBNFFormatTest.java
+++ b/src/test/java/tech/units/indriya/format/EBNFFormatTest.java
@@ -29,9 +29,12 @@
  */
 package tech.units.indriya.format;
 
-import static org.junit.jupiter.api.Assertions.*;
-import static javax.measure.MetricPrefix.*;
-import static tech.units.indriya.unit.Units.*;
+import static javax.measure.MetricPrefix.KILO;
+import static javax.measure.MetricPrefix.MILLI;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static tech.units.indriya.unit.Units.METRE;
 
 import java.math.BigInteger;
 import java.util.logging.Level;
@@ -41,14 +44,13 @@ import javax.measure.Unit;
 import javax.measure.format.MeasurementParseException;
 import javax.measure.format.UnitFormat;
 import javax.measure.quantity.Length;
-import javax.measure.quantity.Time;
 import javax.measure.spi.ServiceProvider;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
-import tech.units.indriya.function.RationalConverter;
+import tech.units.indriya.function.MultiplyConverter;
+import tech.units.indriya.function.RationalNumber;
 import tech.units.indriya.unit.TransformedUnit;
 import tech.units.indriya.unit.Units;
 
@@ -130,7 +132,7 @@ public class EBNFFormatTest {
     public void testTransformed() {
         final String ANGSTROEM_SYM = "\u212B";
         final Unit<Length> ANGSTROEM = new TransformedUnit<Length>(ANGSTROEM_SYM, METRE, METRE,
-                new RationalConverter(BigInteger.ONE, BigInteger.TEN.pow(10)));
+                MultiplyConverter.ofRational(BigInteger.ONE, BigInteger.TEN.pow(10)));
         final String s = format.format(ANGSTROEM);
         assertEquals(ANGSTROEM_SYM, s);
     }

--- a/src/test/java/tech/units/indriya/format/SimpleUnitFormatTest.java
+++ b/src/test/java/tech/units/indriya/format/SimpleUnitFormatTest.java
@@ -29,16 +29,21 @@
  */
 package tech.units.indriya.format;
 
+import static javax.measure.BinaryPrefix.KIBI;
+import static javax.measure.BinaryPrefix.TEBI;
+import static javax.measure.MetricPrefix.KILO;
+import static javax.measure.MetricPrefix.MEGA;
+import static javax.measure.MetricPrefix.MICRO;
+import static javax.measure.MetricPrefix.MILLI;
+import static javax.measure.MetricPrefix.NANO;
 import static org.junit.Assert.assertEquals;
-import static org.junit.jupiter.api.Assertions.*;
-import static javax.measure.BinaryPrefix.*;
-import static javax.measure.MetricPrefix.*;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static tech.units.indriya.format.SimpleUnitFormat.Flavor.ASCII;
 import static tech.units.indriya.unit.Units.CANDELA;
 import static tech.units.indriya.unit.Units.GRAM;
 import static tech.units.indriya.unit.Units.HERTZ;
 import static tech.units.indriya.unit.Units.KILOGRAM;
 import static tech.units.indriya.unit.Units.METRE;
-import static tech.units.indriya.format.SimpleUnitFormat.Flavor.ASCII;
 
 import java.math.BigInteger;
 import java.util.logging.Level;
@@ -59,7 +64,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import tech.units.indriya.function.ExpConverter;
-import tech.units.indriya.function.RationalConverter;
+import tech.units.indriya.function.MultiplyConverter;
+import tech.units.indriya.function.RationalNumber;
 import tech.units.indriya.unit.AlternateUnit;
 import tech.units.indriya.unit.ProductUnit;
 import tech.units.indriya.unit.TransformedUnit;
@@ -146,7 +152,7 @@ public class SimpleUnitFormatTest {
     public void testTransformed() {
         final String ANGSTROEM_SYM = "\u212B";
         final Unit<Length> ANGSTROEM = new TransformedUnit<Length>(ANGSTROEM_SYM, METRE, METRE,
-                new RationalConverter(BigInteger.ONE, BigInteger.TEN.pow(10)));
+                MultiplyConverter.ofRational(RationalNumber.of(BigInteger.ONE, BigInteger.TEN.pow(10))));
         final String s = format.format(ANGSTROEM);
         assertEquals(ANGSTROEM_SYM, s);
     }

--- a/src/test/java/tech/units/indriya/function/CompositionEquivalenceTest.java
+++ b/src/test/java/tech/units/indriya/function/CompositionEquivalenceTest.java
@@ -183,7 +183,7 @@ class CompositionEquivalenceTest {
   public void equivalenceHappyCase() {
 
     AbstractConverter a = new AddConverter(3);
-    AbstractConverter b = new MultiplyConverter(2);
+    AbstractConverter b = DoubleMultiplyConverter.of(2);
 
     AbstractConverter ab = (AbstractConverter) a.concatenate(b);
     AbstractConverter Ba = (AbstractConverter) b.inverse().concatenate(a);
@@ -202,7 +202,7 @@ class CompositionEquivalenceTest {
   public void equivalenceUnhappyCase() {
 
     AbstractConverter a = new AddConverter(3);
-    AbstractConverter b = new MultiplyConverter(2);
+    AbstractConverter b = DoubleMultiplyConverter.of(2);
     AbstractConverter c = new AddConverter(-7);
 
     {        

--- a/src/test/java/tech/units/indriya/function/ConverterTypeUtil.java
+++ b/src/test/java/tech/units/indriya/function/ConverterTypeUtil.java
@@ -63,10 +63,10 @@ class ConverterTypeUtil {
         ()->RationalConverter.of(1, 1), // identity as expressed by this type ... x -> 1/1 * x
         RationalConverter.of(17, 13), // concrete example a ... x -> 17/13 * x
         RationalConverter.of(-34, 17)   ), // concrete example b ... x -> -34/17 * x
-    MULTIPLY(MultiplyConverter.class, 
-        ()->new MultiplyConverter(1.), // identity as expressed by this type ... x -> 1.0 * x
-        new MultiplyConverter(17.23), // concrete example a ... x -> 17.23 * x
-        new MultiplyConverter(-0.333) ), // concrete example b ... x -> -0.333 * x
+    MULTIPLY(DoubleMultiplyConverter.class, 
+        ()->DoubleMultiplyConverter.of(1.), // identity as expressed by this type ... x -> 1.0 * x
+        DoubleMultiplyConverter.of(17.23), // concrete example a ... x -> 17.23 * x
+        DoubleMultiplyConverter.of(-0.333) ), // concrete example b ... x -> -0.333 * x
     ADD(AddConverter.class, 
         ()->new AddConverter(0.), // identity as expressed by this type ... x -> 0 + x
         new AddConverter(-4.5), // concrete example a ... x -> -4.5 + x

--- a/src/test/java/tech/units/indriya/function/DoubleMultiplyConverterTest.java
+++ b/src/test/java/tech/units/indriya/function/DoubleMultiplyConverterTest.java
@@ -30,64 +30,62 @@
 package tech.units.indriya.function;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static tech.units.indriya.NumberAssertions.assertNumberEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
-import tech.units.indriya.NumberAssertions;
+public class DoubleMultiplyConverterTest {
 
-public class AddConverterTest {
-
-  private AddConverter converter;
+  private DoubleMultiplyConverter converter;
 
   @BeforeEach
   public void setUp() throws Exception {
-    converter = new AddConverter(10);
+    converter = DoubleMultiplyConverter.of(2);
   }
 
   @Test
-  public void testEqualityOfTwoConverter() {
-    AddConverter addConverter = new AddConverter(10);
-    assertEquals(addConverter, converter);
-    assertNotNull(addConverter);
+  public void testConvertMethod() {
+    assertEquals(200, converter.convert(100), 0.1);
+    assertEquals(0, converter.convert(0));
+    assertEquals(-200, converter.convert(-100), 0.1);
+  }
+
+  @Test
+  public void testEqualityOfTwoLogConverter() {
+    assertNotNull(converter);
+    assertEquals(DoubleMultiplyConverter.of(2), converter);
+  }
+
+  @Test
+  public void testGetValuePiDivisorConverter() {
+    assertEquals(Double.valueOf(2d), converter.getValue());
+  }
+
+  @Test
+  public void isLinearOfLogConverterTest() {
+    assertTrue(converter.isLinear());
   }
 
   @Test
   public void inverseTest() {
-    assertEquals(new AddConverter(-10), converter.inverse());
-  }
-
-  @Test
-  public void linearTest() {
-    assertFalse(converter.isLinear());
-  }
-
-  @Test
-  public void offsetTest() {
-    assertNumberEquals(10, converter.getOffset(), 1E-12);
-  }
-
-  @Test
-  public void valueTest() {
-    assertNumberEquals(10, converter.getValue(), 1E-12);
-  }
-
-  @Test
-  public void toStringTest() {
-    assertEquals("Add(x -> x + 10)", converter.toString());
-    assertEquals("Add(x -> x - 10)", converter.inverse().toString());
+    assertNotNull(converter.inverse());
+    assertEquals(DoubleMultiplyConverter.of(0.5), converter.inverse());
   }
 
   @Test
   public void identityTest() {
-    assertFalse(converter.isIdentity());
+	  assertTrue(DoubleMultiplyConverter.of(1).isIdentity());
   }
 
   @Test
-  public void conversionStepsTest() {
-    assertNotNull(converter.getConversionSteps());
+  public void valueTest() {
+    assertEquals(Double.valueOf(2), converter.getValue());
+  }
+
+  @Test
+  public void toStringTest() {
+    assertEquals("DoubleMultiply(x -> x * 2.0)", converter.toString());
   }
 }

--- a/src/test/java/tech/units/indriya/function/MixedRadixTest.java
+++ b/src/test/java/tech/units/indriya/function/MixedRadixTest.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
+import static tech.units.indriya.NumberAssertions.assertNumberEquals;
 import static tech.units.indriya.function.MixedRadixTest.USCustomary.FOOT;
 import static tech.units.indriya.function.MixedRadixTest.USCustomary.INCH;
 import static tech.units.indriya.function.MixedRadixTest.USCustomary.PICA;
@@ -74,13 +75,13 @@ public class MixedRadixTest {
         
         
         public static final Unit<Length> FOOT = Units.METRE.transform(
-                new RationalConverter(FOOT_PER_METER.getDividend(), FOOT_PER_METER.getDivisor()));
+                MultiplyConverter.ofRational(FOOT_PER_METER.getDividend(), FOOT_PER_METER.getDivisor()));
         
         public static final Unit<Length> INCH = Units.METRE.transform(
-                new RationalConverter(INCH_PER_METER.getDividend(), INCH_PER_METER.getDivisor()));
+                MultiplyConverter.ofRational(INCH_PER_METER.getDividend(), INCH_PER_METER.getDivisor()));
         
         public static final Unit<Length> PICA = Units.METRE.transform(
-                new RationalConverter(PICA_PER_METER.getDividend(), PICA_PER_METER.getDivisor()));
+                MultiplyConverter.ofRational(PICA_PER_METER.getDividend(), PICA_PER_METER.getDivisor()));
                 
     }
     
@@ -172,8 +173,8 @@ public class MixedRadixTest {
         // then
         
         assertEquals(USCustomary.FOOT, mixedRadix.getPrimaryUnit());
-        NumberAssertions.assertNumberEquals(1.1666666666666667, lengthQuantity.getValue(), 1E-9);
-        NumberAssertions.assertNumberEquals(1.1666666666666667, lengthComp.to(USCustomary.FOOT).getValue(), 1E-9);
+        assertNumberEquals(1.1666666666666667, lengthQuantity.getValue(), 1E-9);
+        assertNumberEquals(1.1666666666666667, lengthComp.to(USCustomary.FOOT).getValue(), 1E-9);
         
     }
     

--- a/src/test/java/tech/units/indriya/function/RationalNumberTest.java
+++ b/src/test/java/tech/units/indriya/function/RationalNumberTest.java
@@ -1,0 +1,103 @@
+/*
+ * Units of Measurement Reference Implementation
+ * Copyright (c) 2005-2019, Units of Measurement project.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of JSR-385, Indriya nor the names of their contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package tech.units.indriya.function;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static tech.units.indriya.NumberAssertions.assertNumberEquals;
+
+import java.math.BigInteger;
+
+import org.junit.jupiter.api.Test;
+
+public class RationalNumberTest {
+
+    @Test
+    public void equalityByValue() {
+        RationalNumber rational_1 = RationalNumber.of(5, 3);   
+        RationalNumber rational_2 = RationalNumber.of(10, 6);
+        
+        assertEquals(rational_1, rational_2);
+        
+    }
+    
+    @Test
+    public void doubleNumberRepresentationWhenSmall() {
+        
+        RationalNumber rational_1 = RationalNumber.of(
+                BigInteger.valueOf(1660538782L), 
+                new BigInteger("1000000000000000000000000000000000000"));
+        
+        RationalNumber rational_2 = RationalNumber.ofDouble(1.660538782E-27);
+        
+        assertEquals(rational_1, rational_2);
+        
+    }
+    
+    @Test
+    public void doubleNumberRepresentationWhenLarge() {
+        
+        RationalNumber rational_1 = RationalNumber.ofInteger(
+                new BigInteger("123456789000000000000000000000000000"));
+        
+        RationalNumber rational_2 = RationalNumber.ofDouble(1.23456789E35);
+        
+        assertEquals(rational_1, rational_2);
+        
+    }
+    
+    @Test
+    public void doubleNumberRepresentationWhenIntegerUnscaled() {
+        
+        RationalNumber rational_1 = RationalNumber.ofInteger(3);
+        
+        RationalNumber rational_2 = RationalNumber.ofDouble(3.);
+        
+        assertEquals(rational_1, rational_2);
+        
+    }
+    
+    
+    @Test
+    public void veryLargeNumberRepresentation() {
+        
+        RationalNumber veryLargeRational= RationalNumber.ofDouble(Double.MAX_VALUE);
+        
+        double actual = veryLargeRational
+                .divide(RationalNumber.ofInteger(Long.MAX_VALUE))
+                .doubleValue();
+        
+        double expected = Double.MAX_VALUE / Long.MAX_VALUE;
+        
+        assertNumberEquals(expected, actual, 1E-12);
+        
+    }
+    
+    
+}

--- a/src/test/java/tech/units/indriya/internal/funtion/radix/MixedRadixSupportTest.java
+++ b/src/test/java/tech/units/indriya/internal/funtion/radix/MixedRadixSupportTest.java
@@ -36,7 +36,6 @@ import org.junit.jupiter.api.Test;
 
 import tech.units.indriya.NumberAssertions;
 import tech.units.indriya.function.MultiplyConverter;
-import tech.units.indriya.function.RationalConverter;
 import tech.units.indriya.function.RationalNumber;
 import tech.units.indriya.internal.function.radix.MixedRadixSupport;
 import tech.units.indriya.internal.function.radix.Radix;
@@ -49,16 +48,14 @@ public class MixedRadixSupportTest {
     
     private Radix[] decimalRadices = {
             
-            new Radix.UnitConverterRadix(MultiplyConverter.of(60.)),
-            new Radix.UnitConverterRadix(MultiplyConverter.of(15.)),
+            Radix.ofNumberFactor(BigDecimal.valueOf(60.)),
+            Radix.ofNumberFactor(BigDecimal.valueOf(15.)),
             
-//            new Radix.UnitConverterRadix(MultiplyConverter.of(BigDecimal.valueOf(60.))),
-//            new Radix.UnitConverterRadix(MultiplyConverter.of(BigDecimal.valueOf(15.))),
     };
 
     private Radix[] rationalRadices = {
-            new Radix.UnitConverterRadix(RationalConverter.of(RationalNumber.ofInteger(60))),
-            new Radix.UnitConverterRadix(RationalConverter.of(RationalNumber.ofInteger(15))),
+            Radix.ofMultiplyConverter(MultiplyConverter.ofRational(RationalNumber.ofInteger(60))),
+            Radix.ofMultiplyConverter(MultiplyConverter.ofRational(RationalNumber.ofInteger(15))),
     };
 
     @Test

--- a/src/test/java/tech/units/indriya/quantity/WolframTuturialTemperatureTest.java
+++ b/src/test/java/tech/units/indriya/quantity/WolframTuturialTemperatureTest.java
@@ -30,7 +30,8 @@
 package tech.units.indriya.quantity;
 
 import static javax.measure.MetricPrefix.KILO;
-import static javax.measure.Quantity.Scale.*;
+import static javax.measure.Quantity.Scale.ABSOLUTE;
+import static javax.measure.Quantity.Scale.RELATIVE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -44,8 +45,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import tech.units.indriya.function.AddConverter;
-import tech.units.indriya.function.RationalConverter;
-import tech.units.indriya.quantity.Quantities;
+import tech.units.indriya.function.MultiplyConverter;
 import tech.units.indriya.unit.TransformedUnit;
 import tech.units.indriya.unit.Units;
 
@@ -59,16 +59,16 @@ import tech.units.indriya.unit.Units;
 class WolframTuturialTemperatureTest {
 
 	public static final Unit<Temperature> DegreesFahrenheit = new TransformedUnit<>(Units.KELVIN,
-			RationalConverter.of(5, 9).concatenate(new AddConverter(459.67)));
+			MultiplyConverter.ofRational(5, 9).concatenate(new AddConverter(459.67)));
 
 	public static final Unit<Temperature> DegreesFahrenheitDifference = new TransformedUnit<>(Units.KELVIN,
-			RationalConverter.of(5, 9));
+	        MultiplyConverter.ofRational(5, 9));
 
 	public static final Unit<Temperature> KelvinsDifference = new TransformedUnit<>(Units.KELVIN,
-			RationalConverter.of(1, 1));
+	        MultiplyConverter.ofRational(1, 1));
 
 	public static final Unit<Temperature> DegreesCelsiusDifference = new TransformedUnit<>(Units.KELVIN,
-			RationalConverter.of(1, 1));
+	        MultiplyConverter.ofRational(1, 1));
 
 	// -- (1) -- Absolute Temperature versus Temperature Difference
 


### PR DESCRIPTION
references #220 #237 and #238 

Original `MultiplyConverter` was renamed to `DoubleMultiplyConverter` and `MultiplyConverter` was reinvented as an interface, that now hides any implementing sub-classes. These are
- RationalConverter
- DoubleMultiplyConverter
- PowerOfIntConverter (unfortunately still visible, but at least the constructors are package private)
- PowerOfPiConverter

RI shall not expose these, because they are implementation details. Instead we provide static factories for all MultiplyConverters with the `MultiplyConverter` interface.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/indriya/242)
<!-- Reviewable:end -->
