### PR TITLE
introduces EncodingUtil to support JavaBeans XML serialization

### DIFF
--- a/src/main/java/tech/units/indriya/quantity/EncodingUtil.java
+++ b/src/main/java/tech/units/indriya/quantity/EncodingUtil.java
@@ -1,0 +1,121 @@
+/*
+ * Units of Measurement Reference Implementation
+ * Copyright (c) 2005-2019, Units of Measurement project.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of JSR-385, Indriya nor the names of their contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package tech.units.indriya.quantity;
+
+import java.beans.Encoder;
+import java.beans.Expression;
+import java.beans.PersistenceDelegate;
+import java.beans.XMLEncoder;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.util.Base64;
+
+import javax.measure.Quantity;
+
+import tech.units.indriya.quantity.time.TemporalQuantity;
+import tech.units.indriya.quantity.time.TimeUnitQuantity;
+
+/**
+ * Provides support for JavaBeans XML serialization of {@link Quantity} instances.
+ * @see {@link java.beans.XMLEncoder}
+ * @author Andi Huber
+ * @since 2.0.2
+ */
+public class EncodingUtil {
+
+    public static void setupXMLEncoder(XMLEncoder encoder) {
+        encoder.setPersistenceDelegate(NumberQuantity.class, QUANTITY_PERSISTENCE_DELEGATE);
+        encoder.setPersistenceDelegate(TemporalQuantity.class, QUANTITY_PERSISTENCE_DELEGATE);
+        encoder.setPersistenceDelegate(TimeUnitQuantity.class, QUANTITY_PERSISTENCE_DELEGATE);
+    }
+    
+    public static String base64Encode(Quantity<?> quantity) throws IOException {
+        
+        byte[] buffer;
+        
+        try(ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+            ObjectOutputStream oos = new ObjectOutputStream(bos);
+            oos.writeObject(quantity);
+            oos.close();
+            buffer = bos.toByteArray();
+        }
+        
+        return Base64.getEncoder().encodeToString(buffer);
+    }
+    
+    public static Quantity<?> base64Decode(String base64) throws IOException, ClassNotFoundException {
+        
+        final byte[] buffer = Base64.getDecoder().decode(base64);
+        
+        Quantity<?> q;
+        
+        try(ByteArrayInputStream bis = new ByteArrayInputStream(buffer)) {
+            ObjectInputStream ois = new ObjectInputStream(bis);
+            q = (Quantity<?>) ois.readObject();
+        }
+        
+        return q;
+    }
+
+    
+    // -- HELPER
+    
+    private final static PersistenceDelegateForQuantity QUANTITY_PERSISTENCE_DELEGATE = 
+            new PersistenceDelegateForQuantity();
+    
+    private static class PersistenceDelegateForQuantity extends PersistenceDelegate {
+        
+        @Override
+        protected Expression instantiate(Object oldInstance, Encoder out) {
+
+            Quantity<?> quantity = (Quantity<?>) oldInstance;
+            String base64EncodedQuantity;
+            
+            try {
+                base64EncodedQuantity = base64Encode(quantity);
+            } catch (IOException e) {
+                throw new IllegalArgumentException(e);
+            }
+            
+            return new Expression(
+                    oldInstance,
+                    EncodingUtil.class,
+                    "base64Decode",
+                    new Object[]{
+                            base64EncodedQuantity
+                    });
+        }
+    }
+    
+
+}

--- a/src/main/java/tech/units/indriya/spi/NumberSystem.java
+++ b/src/main/java/tech/units/indriya/spi/NumberSystem.java
@@ -30,15 +30,48 @@
 package tech.units.indriya.spi;
 
 /**
- * Provides basic {@link Number} operations. 
+ * Provides arithmetic {@link Number} operations on an implementation specific set of 
+ * {@link Number} types.
  * <p>
- * Within a given set of {@link Number} types, supports any combination of number operations, 
- * such that any operation result is also a member of this set. 
+ * Let <em>S</em> be the set of possible {@link Number} values within the (given) set of 
+ * {@link Number} types.<br>
+ * Then <em>S</em> is <a href="https://en.wikipedia.org/wiki/Closure_(mathematics)">closed</a> 
+ * under the collection of {@link NumberSystem}'s methods.   
+ * 
+ * @implNote
+ * Given <em>S</em> the set of possible {@link Number} values within implementation specific 
+ * set of (supported) {@link Number} types:<br>
+ * - implemented methods must support any {@link Number} arguments from <em>S</em><br>
+ * - implemented methods must also have their {@link Number} results to be in <em>S</em><br>
  *  
  * @author Andi Huber
  * @since 2.0
+ * @see <a href="https://en.wikipedia.org/wiki/Closure_(mathematics)">Closure (wikipedia)</a>
  */
 public interface NumberSystem {
+    
+    /**
+     * Immutable value type, holder of 2 numbers.
+     */
+    public final static class DivisionResult {
+        /**
+         * originating from x / y
+         */
+        public final Number quotient;
+        /**
+         * originating from x % y 
+         */
+        public final Number remainder;
+        
+        public static DivisionResult of(Number quotient, Number remainder) {
+            return new DivisionResult(quotient, remainder);
+        }
+        
+        private DivisionResult(Number quotient, Number remainder) {
+            this.quotient = quotient;
+            this.remainder = remainder;
+        }
+    }
 
     /**
      * Returns the sum of given {@code x} and {@code y} as a {@link Number} that best

--- a/src/test/java/tech/units/indriya/format/SamplingUtil.java
+++ b/src/test/java/tech/units/indriya/format/SamplingUtil.java
@@ -1,0 +1,139 @@
+/*
+ * Units of Measurement Reference Implementation
+ * Copyright (c) 2005-2019, Units of Measurement project.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of JSR-385, Indriya nor the names of their contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package tech.units.indriya.format;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.temporal.ChronoUnit;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import javax.measure.BinaryPrefix;
+import javax.measure.MetricPrefix;
+import javax.measure.Prefix;
+import javax.measure.Unit;
+
+import tech.units.indriya.format.UnitFormatRoundtripUtil.NonPrefixedUnits;
+import tech.units.indriya.function.RationalNumber;
+import tech.units.indriya.quantity.Quantities;
+import tech.units.indriya.quantity.time.TemporalQuantity;
+import tech.units.indriya.unit.Units;
+
+/**
+ * Samples Units, Numbers and Prefixes to feed test cases.
+ */
+public class SamplingUtil {
+
+    public static Stream<Number> numbers() {
+        return Stream.of(
+                1.2345d,
+                RationalNumber.of(2,3),
+                1234,
+                1234L,
+                BigInteger.valueOf(1234L),
+                new BigDecimal("0.1")
+                );
+    }
+    
+    public static Stream<Prefix> prefixes() {
+        return Stream.of(MetricPrefix.values(), BinaryPrefix.values())
+                .flatMap(Stream::of);
+    }
+    
+    public static Stream<Unit<?>> units() {
+        return Stream.of(
+                nonPrefixedUnits(),
+                additionalUnits(),
+                temporalQuantityUnits(),
+                composedUnits(),
+                compoundUnits()
+                )
+                .flatMap(Function.identity());
+    }
+    
+    // -- HELPER
+    
+    private static Stream<Unit<?>> nonPrefixedUnits() {
+        return Stream.of(NonPrefixedUnits.values())
+                .map(u->u.unit);
+    }
+    
+    private static Stream<Unit<?>> additionalUnits() {
+        return Stream.of(
+                Units.PERCENT,
+                Units.SQUARE_METRE,
+                Units.CUBIC_METRE
+                );
+    }
+    
+    private static Stream<Unit<?>> composedUnits() {
+        return Stream.of(
+                Quantities.getQuantity(1, Units.METRE)
+                .multiply(Quantities.getQuantity(1, Units.SECOND))
+                .getUnit(),
+                
+                Quantities.getQuantity(1, Units.METRE)
+                .divide(Quantities.getQuantity(1, Units.SECOND))
+                .getUnit()
+                
+                );
+    }
+    
+    private static Stream<Unit<?>> compoundUnits() {
+        return Stream.of(
+                Quantities.getQuantity(1, Units.METRE)
+                .multiply(Quantities.getQuantity(1, Units.SECOND))
+                .getUnit(),
+                
+                Quantities.getQuantity(1, Units.METRE)
+                .divide(Quantities.getQuantity(1, Units.SECOND))
+                .getUnit()
+                
+                );
+    }
+    
+    
+    private static Stream<Unit<?>> temporalQuantityUnits() {
+        
+        return Stream.of(ChronoUnit.values())
+        .map(chronoUnit->{
+            try {
+                return TemporalQuantity.of(1, chronoUnit);
+            } catch (Exception e) {
+                // TemporalQuantity only supports DAYS, HOURS, MICROS, MILLIS, MINUTES, NANOS, SECONDS
+                return null; 
+            }
+        })
+        .filter(Objects::nonNull)
+        .map(TemporalQuantity::getUnit);
+    }
+    
+}

--- a/src/test/java/tech/units/indriya/quantity/EncodingUtilTest.java
+++ b/src/test/java/tech/units/indriya/quantity/EncodingUtilTest.java
@@ -1,0 +1,180 @@
+/*
+ * Units of Measurement Reference Implementation
+ * Copyright (c) 2005-2019, Units of Measurement project.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of JSR-385, Indriya nor the names of their contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package tech.units.indriya.quantity;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.beans.XMLDecoder;
+import java.beans.XMLEncoder;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.stream.Stream;
+
+import javax.measure.Prefix;
+import javax.measure.Quantity;
+import javax.measure.Unit;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import tech.units.indriya.format.SamplingUtil;
+import tech.units.indriya.unit.Units;
+
+/**
+ * Testing serialization round-trips for all built-in Quantity types. 
+ */
+class EncodingUtilTest {
+    
+    private EncodingRoundtrip encodingRoundtrip;
+    
+    @BeforeEach
+    void setup() {
+        encodingRoundtrip = new EncodingRoundtrip();
+    }
+    
+    @Test
+    void encodeDecodeRoundtripWhenCompound() throws IOException {
+        @SuppressWarnings("unchecked")
+        Quantity<?> quantity = Quantities.getQuantity(
+                new Number[]{1, 2, 3}, 
+                new Unit[]{Units.DAY, Units.HOUR, Units.MINUTE});
+        encodingRoundtrip.test(quantity);
+    } 
+    
+
+    /**
+     * We cycle through all {@code FormatTestingUtil.NonPrefixedUnits} and 
+     * for each such candidate test, whether XML encoding/decoding are 
+     * consistent.
+     * @throws IOException 
+     */
+    @ParameterizedTest(name = "{index} => unit=''{0}'', amount=''{1}'' ")
+    @DisplayName("XML serialization roundtrip spanning {Unit, Amount} should succeed")
+    @MethodSource("provideRoundtripArgs_unit_amount")
+    void encodeDecodeRoundtrip(Unit<?> unit, Number amount) throws IOException {
+        Quantity<?> quantity = Quantities.getQuantity(amount, unit);
+        encodingRoundtrip.test(quantity);
+    }
+    
+    /**
+     * We cycle through all {@code FormatTestingUtil.NonPrefixedUnits} and 
+     * for each such candidate test, whether XML encoding/decoding are 
+     * consistent.
+     * @throws IOException 
+     */
+    @ParameterizedTest(name = "{index} => unit=''{0}'', amount=''{1}'' ")
+    @DisplayName("XML serialization roundtrip spanning {Unit, Prefix} should succeed")
+    @MethodSource("provideRoundtripArgs_unit_prefix")
+    void encodeDecodeRoundtrip(Unit<?> unit, Prefix prefix) throws IOException {
+        Quantity<?> quantity = Quantities.getQuantity(1.2345, unit.prefix(prefix));
+        encodingRoundtrip.test(quantity);
+    }       
+
+    // -- HELPER
+    
+    private static Stream<Arguments> provideRoundtripArgs_unit_amount() {
+        // span a 2 dimensional finite space of {Unit, Amount} 
+        return SamplingUtil.units()
+        .flatMap(unit->
+            SamplingUtil.numbers()
+            .map(amount->Arguments.of(unit, amount))
+        );
+        
+    }
+    
+    private static Stream<Arguments> provideRoundtripArgs_unit_prefix() {
+        // span a 2 dimensional finite space of {Unit, Prefix} 
+        return SamplingUtil.units()
+        .flatMap(unit->
+            SamplingUtil.prefixes()
+            .map(prefix->Arguments.of(unit, prefix))
+        );
+        
+    }
+    
+
+    private static <Q extends Quantity<? extends Q>> void assertQuantityEquals(Q q1, Q q2) {
+        assertEquals(q1, q2);
+    }
+    
+    private static class EncodingRoundtrip {
+        
+        public <Q extends Quantity<? extends Q>> void test(final Q quantity) throws IOException {
+            assertQuantityEquals(quantity, run(quantity));
+        }
+
+        /**
+         * Writes given originalQuantity as serialized XML to in-memory buffer, 
+         * then reconstructs the quantity from same buffer and returns it
+         * @throws IOException
+         */
+        @SuppressWarnings("unchecked")
+        private <Q extends Quantity<? extends Q>> Q run(final Q originalQuantity) throws IOException {
+
+            byte[] buffer;
+
+            // write XML to buffer
+            try(ByteArrayOutputStream bos = new ByteArrayOutputStream()) {
+                XMLEncoder encoder = new XMLEncoder(bos);
+                EncodingUtil.setupXMLEncoder(encoder);
+
+                encoder.writeObject(originalQuantity);
+                encoder.close();
+
+                buffer = bos.toByteArray();
+
+            } 
+            
+            // debug .. System.out.println(new String(buffer));
+
+            Q reconstructedQuantity;
+            
+            // read XML from buffer
+            try(ByteArrayInputStream bis = new ByteArrayInputStream(buffer)) {
+                XMLDecoder decoder = new XMLDecoder(bis);
+
+                reconstructedQuantity = (Q) decoder.readObject();
+
+                decoder.close();
+            } 
+            
+            return reconstructedQuantity;
+
+        }
+        
+
+    }
+
+}

--- a/src/test/java/tech/units/indriya/quantity/EncodingUtilTest.java
+++ b/src/test/java/tech/units/indriya/quantity/EncodingUtilTest.java
@@ -75,9 +75,8 @@ class EncodingUtilTest {
     
 
     /**
-     * We cycle through all {@code FormatTestingUtil.NonPrefixedUnits} and 
-     * for each such candidate test, whether XML encoding/decoding are 
-     * consistent.
+     * We cycle through all {Unit, Amount} combinations and test 
+     * whether XML encoding/decoding are consistent.
      * @throws IOException 
      */
     @ParameterizedTest(name = "{index} => unit=''{0}'', amount=''{1}'' ")
@@ -89,12 +88,11 @@ class EncodingUtilTest {
     }
     
     /**
-     * We cycle through all {@code FormatTestingUtil.NonPrefixedUnits} and 
-     * for each such candidate test, whether XML encoding/decoding are 
-     * consistent.
+     * We cycle through all {Unit, Prefix} combinations and test 
+     * whether XML encoding/decoding are consistent.
      * @throws IOException 
      */
-    @ParameterizedTest(name = "{index} => unit=''{0}'', amount=''{1}'' ")
+    @ParameterizedTest(name = "{index} => unit=''{0}'', prefix=''{1}'' ")
     @DisplayName("XML serialization roundtrip spanning {Unit, Prefix} should succeed")
     @MethodSource("provideRoundtripArgs_unit_prefix")
     void encodeDecodeRoundtrip(Unit<?> unit, Prefix prefix) throws IOException {


### PR DESCRIPTION
in reference to #264:

Most of the new code is for testing.

The encoding/decoding code is simple and bullet-proof (does not require formatting/parsing), with the trade-off, that the generated serialized XML form is not human readable. That is, the serialized XML content is binary data converted to base64.

(also improves java-doc on NumberSystem)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/indriya/266)
<!-- Reviewable:end -->
