### PR TITLE
285: have Quantity amounts narrowed on construction

### DIFF
--- a/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
+++ b/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
@@ -44,7 +44,7 @@ import tech.units.indriya.spi.NumberSystem;
  * {@link RationalNumber} type.   
  * 
  * @author Andi Huber
- * @since 2.1
+ * @since 2.0
  */
 public class DefaultNumberSystem implements NumberSystem {
     

--- a/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
+++ b/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
@@ -44,7 +44,7 @@ import tech.units.indriya.spi.NumberSystem;
  * {@link RationalNumber} type.   
  * 
  * @author Andi Huber
- * @since 2.0
+ * @since 2.1
  */
 public class DefaultNumberSystem implements NumberSystem {
     
@@ -427,6 +427,9 @@ public class DefaultNumberSystem implements NumberSystem {
         
         if(number instanceof Double || number instanceof Float) {
             final double doubleValue = number.doubleValue();
+            if(!Double.isFinite(doubleValue)) {
+                throw unsupportedNumberValue(doubleValue);
+            }
             if(doubleValue % 1 == 0) {
                 // double represents an integer
                 return narrow(BigDecimal.valueOf(doubleValue));
@@ -517,6 +520,15 @@ public class DefaultNumberSystem implements NumberSystem {
     
     
     // -- HELPER
+    
+    private IllegalArgumentException unsupportedNumberValue(Number number) {
+        final String msg = String.format("Unsupported number value '%s' of type '%s' in number system '%s'",
+                "" + number,
+                number.getClass(),
+                this.getClass().getName());
+        
+        return new IllegalArgumentException(msg);
+    }
     
     private IllegalArgumentException unsupportedNumberType(Number number) {
         final String msg = String.format("Unsupported number type '%s' in number system '%s'",

--- a/src/main/java/tech/units/indriya/quantity/NumberQuantity.java
+++ b/src/main/java/tech/units/indriya/quantity/NumberQuantity.java
@@ -41,6 +41,7 @@ import javax.measure.UnitConverter;
 import tech.units.indriya.AbstractQuantity;
 import tech.units.indriya.ComparableQuantity;
 import tech.units.indriya.function.AddConverter;
+import tech.units.indriya.function.Calculus;
 import tech.units.indriya.internal.function.Calculator;
 
 /**
@@ -57,7 +58,7 @@ import tech.units.indriya.internal.function.Calculator;
  *          The type of the quantity.
  * @author Andi Huber
  * @author Werner Keil
- * @version 1.2
+ * @version 1.3
  * @since 1.0
  * 
  */
@@ -72,7 +73,7 @@ public class NumberQuantity<Q extends Quantity<Q>> extends AbstractQuantity<Q> {
      */
     protected NumberQuantity(Number number, Unit<Q> unit, Scale sc) {
       super(unit, sc);
-      value = number;
+      value = Calculus.currentNumberSystem().narrow(number); // also takes care of invalid number values (infinity, ...)
     }
     
     protected NumberQuantity(Number number, Unit<Q> unit) {

--- a/src/test/java/tech/units/indriya/format/EBNFPrefixTest.java
+++ b/src/test/java/tech/units/indriya/format/EBNFPrefixTest.java
@@ -82,14 +82,14 @@ public class EBNFPrefixTest {
 	@Test
 	public void testMega() {
 		Quantity<Mass> m1 = Quantities.getQuantity(1.0, MEGA(Units.GRAM));
-		assertEquals(1d, m1.getValue());
+		assertNumberEquals(1d, m1.getValue(), 1E-12);
 		assertEquals("Mg", format.format(m1.getUnit()));
 	}
 
 	@Test
 	public void testDeci() {
 		Quantity<Volume> m1 = Quantities.getQuantity(1.0, LITRE);
-		assertEquals(1d, m1.getValue());
+		assertNumberEquals(1d, m1.getValue(), 1E-12);
 		assertEquals("l", format.format(m1.getUnit()));
 
 		Quantity<Volume> m2 = m1.to(DECI(LITRE));
@@ -100,21 +100,21 @@ public class EBNFPrefixTest {
 	@Test
 	public void testMilli() {
 		Quantity<Mass> m1 = Quantities.getQuantity(1.0, MILLI(Units.GRAM));
-		assertEquals(1d, m1.getValue());
+		assertNumberEquals(1d, m1.getValue(), 1E-12);
 		assertEquals("mg", format.format(m1.getUnit()));
 	}
 
 	@Test
 	public void testMilli2() {
 		Quantity<Volume> m1 = Quantities.getQuantity(10, MILLI(LITRE));
-		assertEquals(10, m1.getValue());
+		assertNumberEquals(10, m1.getValue(), 1E-12);
 		assertEquals("ml", format.format(m1.getUnit()));
 	}
 
 	@Test
 	public void testMilli3() {
 		Quantity<Volume> m1 = Quantities.getQuantity(1.0, LITRE);
-		assertEquals(1d, m1.getValue());
+		assertNumberEquals(1d, m1.getValue(), 1E-12);
 		assertEquals("l", format.format(m1.getUnit()));
 
 		Quantity<Volume> m2 = m1.to(MILLI(LITRE));
@@ -125,7 +125,7 @@ public class EBNFPrefixTest {
 	@Test
 	public void testMilli4() {
 		Quantity<Volume> m1 = Quantities.getQuantity(1.0, MILLI(LITRE));
-		assertEquals(1d, m1.getValue());
+		assertNumberEquals(1d, m1.getValue(), 1E-12);
 		assertEquals("ml", format.format(m1.getUnit()));
 
 		Quantity<Volume> m2 = m1.to(LITRE);
@@ -136,7 +136,7 @@ public class EBNFPrefixTest {
 	@Test
 	public void testMicro2() {
 		Quantity<Length> m1 = Quantities.getQuantity(1.0, Units.METRE);
-		assertEquals(1d, m1.getValue());
+		assertNumberEquals(1d, m1.getValue(), 1E-12);
 		assertEquals("m", format.format(m1.getUnit()));
 
 		final Quantity<Length> m2 = m1.to(MICRO(Units.METRE));
@@ -147,7 +147,7 @@ public class EBNFPrefixTest {
 	@Test
 	public void testNano() {
 		Quantity<Mass> m1 = Quantities.getQuantity(1.0, Units.GRAM);
-		assertEquals(1d, m1.getValue());
+		assertNumberEquals(1d, m1.getValue(), 1E-12);
 		assertEquals("g", format.format(m1.getUnit()));
 
 		final Quantity<Mass> m2 = m1.to(NANO(Units.GRAM));
@@ -158,7 +158,7 @@ public class EBNFPrefixTest {
 	@Test
 	public void testNano2() {
 		Quantity<Length> m1 = Quantities.getQuantity(1.0, Units.METRE);
-		assertEquals(1d, m1.getValue());
+		assertNumberEquals(1d, m1.getValue(), 1E-12);
 		assertEquals("m", format.format(m1.getUnit()));
 
 		final Quantity<Length> m2 = m1.to(NANO(Units.METRE));

--- a/src/test/java/tech/units/indriya/format/QuantityFormatTest.java
+++ b/src/test/java/tech/units/indriya/format/QuantityFormatTest.java
@@ -236,7 +236,7 @@ public class QuantityFormatTest {
     public void testParseDelim1() {
         QuantityFormat format1 = NumberDelimiterQuantityFormat.getInstance(DecimalFormat.getInstance(), SimpleUnitFormat.getInstance());
         Quantity<?> parsed1 = format1.parse("1 m");
-        assertEquals(1L, parsed1.getValue());
+        assertNumberEquals(1L, parsed1.getValue(), 1E-12);
         assertEquals(METRE, parsed1.getUnit());
     }
 
@@ -262,7 +262,7 @@ public class QuantityFormatTest {
     public void testParseAtPosition() {
         QuantityFormat format1 = NumberDelimiterQuantityFormat.getInstance(DecimalFormat.getInstance(), SimpleUnitFormat.getInstance());
         Quantity<?> parsed1 = format1.parse("1 km 2 m", new ParsePosition(5));
-        assertEquals(2L, parsed1.getValue());
+        assertNumberEquals(2L, parsed1.getValue(), 1E-12);
         assertEquals(METRE, parsed1.getUnit());
     }
 }

--- a/src/test/java/tech/units/indriya/quantity/QuantitiesTest.java
+++ b/src/test/java/tech/units/indriya/quantity/QuantitiesTest.java
@@ -31,6 +31,7 @@ package tech.units.indriya.quantity;
 
 import static javax.measure.Quantity.Scale.RELATIVE;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static tech.units.indriya.NumberAssertions.assertNumberEquals;
 import static tech.units.indriya.unit.Units.CELSIUS;
@@ -45,7 +46,6 @@ import javax.measure.quantity.Speed;
 import javax.measure.quantity.Temperature;
 import javax.measure.quantity.Time;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import tech.units.indriya.ComparableQuantity;
@@ -55,7 +55,7 @@ import tech.units.indriya.unit.Units;
  *
  * @author Werner Keil
  * @author Andi Huber
- * @version 0.5
+ * @version 0.6
  */
 public class QuantitiesTest {
 
@@ -63,6 +63,17 @@ public class QuantitiesTest {
   public void ofTest() {
     Quantity<Pressure> pressure = Quantities.getQuantity(BigDecimal.ONE, PASCAL);
     assertEquals(PASCAL, pressure.getUnit());
+  }
+  
+  @Test
+  public void canOnlyUseFinteAmountsTestNan() {
+    assertThrows(IllegalArgumentException.class, ()->Quantities.getQuantity(Double.NaN, PASCAL));  
+  }
+  
+  @Test
+  public void canOnlyUseFinteAmountsTestInfinity() {
+    assertThrows(IllegalArgumentException.class, ()->Quantities.getQuantity(Double.POSITIVE_INFINITY, PASCAL));  
+    assertThrows(IllegalArgumentException.class, ()->Quantities.getQuantity(Double.NEGATIVE_INFINITY, PASCAL));
   }
 
   @Test
@@ -77,24 +88,15 @@ public class QuantitiesTest {
     Quantity<Pressure> floatQuantity = Quantities.getQuantity(Float.valueOf("2"), PASCAL);
     Quantity<Pressure> doubleQuantity = Quantities.getQuantity(Double.valueOf("2"), PASCAL);
 
-    assertTrue(Short.class.isInstance(shortQuantity.getValue()));
-    assertTrue(Byte.class.isInstance(byteQuantity.getValue()));
-    assertTrue(Long.class.isInstance(longQuantity.getValue()));
-    assertTrue(Integer.class.isInstance(intQuantity.getValue()));
-    assertTrue(Float.class.isInstance(floatQuantity.getValue()));
-    assertTrue(Double.class.isInstance(doubleQuantity.getValue()));
-    assertTrue(BigInteger.class.isInstance(bigIntegerQuantity.getValue()));
-    assertTrue(BigDecimal.class.isInstance(bigDecimalQuantity.getValue()));
+    assertNumberEquals(2, shortQuantity.getValue(), 1E-12);
+    assertNumberEquals(2, byteQuantity.getValue(), 1E-12);
+    assertNumberEquals(2, longQuantity.getValue(), 1E-12);
+    assertNumberEquals(2, intQuantity.getValue(), 1E-12);
+    assertNumberEquals(2, floatQuantity.getValue(), 1E-12);
+    assertNumberEquals(2, doubleQuantity.getValue(), 1E-12);
+    assertNumberEquals(1, bigIntegerQuantity.getValue(), 1E-12);
+    assertNumberEquals(1, bigDecimalQuantity.getValue(), 1E-12);
 
-// //TODO[220] remove obsolete    
-//    assertTrue(ShortQuantity.class.isInstance(shortQuantity));
-//    assertTrue(ByteQuantity.class.isInstance(byteQuantity));
-//    assertTrue(LongQuantity.class.isInstance(longQuantity));
-//    assertTrue(NumberQuantity.class.isInstance(intQuantity)); // workaround
-//    assertTrue(NumberQuantity.class.isInstance(floatQuantity)); // workaround
-//    assertTrue(DoubleQuantity.class.isInstance(doubleQuantity));
-//    assertTrue(BigIntegerQuantity.class.isInstance(bigIntegerQuantity));
-//    assertTrue(DecimalQuantity.class.isInstance(bigDecimalQuantity));
   }
 
   @Test
@@ -109,25 +111,15 @@ public class QuantitiesTest {
     Quantity<Temperature> floatQuantity = Quantities.getQuantity(Float.valueOf("2"), CELSIUS, RELATIVE);
     Quantity<Temperature> doubleQuantity = Quantities.getQuantity(Double.valueOf("2"), CELSIUS, RELATIVE);
 
-    assertTrue(Short.class.isInstance(shortQuantity.getValue()));
-    assertTrue(Byte.class.isInstance(byteQuantity.getValue()));
-    assertTrue(Long.class.isInstance(longQuantity.getValue()));
-    assertTrue(Integer.class.isInstance(intQuantity.getValue()));
-    assertTrue(Float.class.isInstance(floatQuantity.getValue()));
-    assertTrue(Double.class.isInstance(doubleQuantity.getValue()));
-    assertTrue(BigInteger.class.isInstance(bigIntegerQuantity.getValue()));
-    assertTrue(BigDecimal.class.isInstance(bigDecimalQuantity.getValue()));
+    assertNumberEquals(2, shortQuantity.getValue(), 1E-12);
+    assertNumberEquals(2, byteQuantity.getValue(), 1E-12);
+    assertNumberEquals(2, longQuantity.getValue(), 1E-12);
+    assertNumberEquals(2, intQuantity.getValue(), 1E-12);
+    assertNumberEquals(2, floatQuantity.getValue(), 1E-12);
+    assertNumberEquals(2, doubleQuantity.getValue(), 1E-12);
+    assertNumberEquals(1, bigIntegerQuantity.getValue(), 1E-12);
+    assertNumberEquals(1, bigDecimalQuantity.getValue(), 1E-12);
 
-//TODO[220] remove obsolete
-//    assertTrue(ShortQuantity.class.isInstance(shortQuantity));
-//    assertTrue(ByteQuantity.class.isInstance(byteQuantity));
-//    assertTrue(LongQuantity.class.isInstance(longQuantity));
-//    assertTrue(NumberQuantity.class.isInstance(intQuantity)); // workaround
-//    assertTrue(NumberQuantity.class.isInstance(floatQuantity)); // workaround
-//    assertTrue(DoubleQuantity.class.isInstance(doubleQuantity));
-//    assertTrue(BigIntegerQuantity.class.isInstance(bigIntegerQuantity));
-//    assertTrue(DecimalQuantity.class.isInstance(bigDecimalQuantity));
-    
     assertEquals(RELATIVE, shortQuantity.getScale());
     assertEquals(RELATIVE, byteQuantity.getScale());
     assertEquals(RELATIVE, longQuantity.getScale());
@@ -146,11 +138,10 @@ public class QuantitiesTest {
   }
 
   @Test
-  @Disabled("fails because of MultiplyConverter not being sufficiently accurate")
+  //@Disabled("fails because of MultiplyConverter not being sufficiently accurate")
   public void quantityEquivalentTest() {
       ComparableQuantity<Speed> shouldBe = Quantities.getQuantity(15, Units.KILOMETRE_PER_HOUR);
       Quantity<Speed> parsedSpeed = Quantities.getQuantity("15.0 km/h").asType(Speed.class);
-
       assertTrue(shouldBe.isEquivalentTo(parsedSpeed));
   }
 }

--- a/src/test/java/tech/units/indriya/quantity/QuantityRangeTest.java
+++ b/src/test/java/tech/units/indriya/quantity/QuantityRangeTest.java
@@ -43,9 +43,6 @@ import javax.measure.quantity.Mass;
 
 import org.junit.jupiter.api.Test;
 
-import tech.units.indriya.quantity.Quantities;
-import tech.units.indriya.quantity.QuantityRange;
-
 public class QuantityRangeTest {
   private final Quantity<Mass> zeroKilogram = Quantities.getQuantity(0d, KILOGRAM);
   private final Quantity<Mass> oneKilogram = Quantities.getQuantity(1d, KILOGRAM);
@@ -254,7 +251,7 @@ public class QuantityRangeTest {
    */
   @Test
   public void toStringProducesCorrectResultWithResolution() {
-    assertEquals("min= 1.0 kg, max= 10.0 kg, res= 2.0 kg", oneToTenKilogramWithTwoKilogramResolution.toString());
+    assertEquals("min= 1 kg, max= 10 kg, res= 2 kg", oneToTenKilogramWithTwoKilogramResolution.toString());
   }
 
   /**
@@ -262,7 +259,7 @@ public class QuantityRangeTest {
    */
   @Test
   public void toStringProducesCorrectResultWithoutResolution() {
-    assertEquals("min= 1.0 kg, max= 10.0 kg", oneToTenKilogram.toString());
+    assertEquals("min= 1 kg, max= 10 kg", oneToTenKilogram.toString());
   }
 
   /**

--- a/src/test/java/tech/units/indriya/quantity/TemperatureTest.java
+++ b/src/test/java/tech/units/indriya/quantity/TemperatureTest.java
@@ -52,7 +52,7 @@ class TemperatureTest {
 	@Test
 	void testInstantiate() {
 		Quantity<Temperature> t = Quantities.getQuantity(23.0d, CELSIUS); // 23.0 °C
-		assertEquals("23.0 ℃", t.toString());
+		assertEquals("23 ℃", t.toString());
 	}
 
 	@Test

--- a/src/test/java/tech/units/indriya/spi/RangeTest.java
+++ b/src/test/java/tech/units/indriya/spi/RangeTest.java
@@ -36,12 +36,10 @@ import javax.measure.Quantity;
 import javax.measure.quantity.Mass;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import tech.units.indriya.quantity.Quantities;
 import tech.units.indriya.quantity.QuantityRange;
-import tech.units.indriya.spi.Range;
 
 public class RangeTest {
   private Quantity<Mass> min;
@@ -79,6 +77,6 @@ public class RangeTest {
 
   @Test
   public void testToString() {
-    assertEquals("min= 1.0 kg, max= 10.0 kg, res= 2.0 kg", range.toString());
+    assertEquals("min= 1 kg, max= 10 kg, res= 2 kg", range.toString());
   }
 }

--- a/src/test/java/tech/units/indriya/unit/PrefixTest.java
+++ b/src/test/java/tech/units/indriya/unit/PrefixTest.java
@@ -87,14 +87,14 @@ public class PrefixTest {
 	@Test
 	public void testMega() {
 		Quantity<Mass> m1 = Quantities.getQuantity(1.0, MEGA(Units.GRAM));
-		assertEquals(1d, m1.getValue());
+		assertNumberEquals(1d, m1.getValue(), 1E-12);
 		assertEquals("Mg", m1.getUnit().toString());
 	}
 
 	@Test
 	public void testDeci() {
 		Quantity<Volume> m1 = Quantities.getQuantity(1.0, LITRE);
-		assertEquals(1d, m1.getValue());
+		assertNumberEquals(1d, m1.getValue(), 1E-12);
 		assertEquals("l", m1.getUnit().toString());
 
 		Quantity<Volume> m2 = m1.to(DECI(LITRE));
@@ -105,7 +105,7 @@ public class PrefixTest {
 	@Test
 	public void testMilli() {
 		Quantity<Mass> m1 = Quantities.getQuantity(1.0, MILLI(Units.GRAM));
-		assertEquals(1d, m1.getValue());
+		assertNumberEquals(1d, m1.getValue(), 1E-12);
 		assertEquals("mg", m1.getUnit().toString());
 	}
 
@@ -119,7 +119,7 @@ public class PrefixTest {
 	@Test
 	public void testMilli3() {
 		Quantity<Volume> m1 = Quantities.getQuantity(1.0, LITRE);
-		assertEquals(1d, m1.getValue());
+		assertNumberEquals(1d, m1.getValue(), 1E-12);
 		assertEquals("l", m1.getUnit().toString());
 
 		Quantity<Volume> m2 = m1.to(MILLI(LITRE));
@@ -130,7 +130,7 @@ public class PrefixTest {
 	@Test
 	public void testMilli4() {
 		Quantity<Volume> m1 = Quantities.getQuantity(1.0, MILLI(LITRE));
-		assertEquals(1d, m1.getValue());
+		assertNumberEquals(1d, m1.getValue(), 1E-12);
 		assertEquals("ml", m1.getUnit().toString());
 
 		Quantity<Volume> m2 = m1.to(LITRE);
@@ -141,7 +141,7 @@ public class PrefixTest {
 	@Test
 	public void testMicro2() {
 		Quantity<Length> m1 = Quantities.getQuantity(1.0, Units.METRE);
-		assertEquals(1d, m1.getValue());
+		assertNumberEquals(1d, m1.getValue(), 1E-12);
 		assertEquals("m", m1.getUnit().toString());
 
 		Quantity<Length> m2 = m1.to(MICRO(Units.METRE));
@@ -152,7 +152,7 @@ public class PrefixTest {
 	@Test
 	public void testNano() {
 		Quantity<Mass> m1 = Quantities.getQuantity(1.0, Units.GRAM);
-		assertEquals(1d, m1.getValue());
+		assertNumberEquals(1d, m1.getValue(), 1E-12);
 		assertEquals("g", m1.getUnit().toString());
 
 		Quantity<Mass> m2 = m1.to(NANO(Units.GRAM));
@@ -163,7 +163,7 @@ public class PrefixTest {
 	@Test
 	public void testNano2() {
 		Quantity<Length> m1 = Quantities.getQuantity(1.0, Units.METRE);
-		assertEquals(1d, m1.getValue());
+		assertNumberEquals(1d, m1.getValue(), 1E-12);
 		assertEquals("m", m1.getUnit().toString());
 
 		Quantity<Length> m2 = m1.to(NANO(Units.METRE));


### PR DESCRIPTION
this is done in the default NumberSystem implementation
users can plugin their own NumberSystem if needed

our default narrow(Number) implementation now checks for non-finite number values and throws an IllegalArgumentException if such is detected

in reference to issue #285

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/indriya/286)
<!-- Reviewable:end -->
