### PR TITLE
329: Retain floating point precision when converting floats

### DIFF
--- a/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
+++ b/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
@@ -763,19 +763,13 @@ public class DefaultNumberSystem implements NumberSystem {
         
         // at this point we know, that wide is one of {Double, Float}
         
-        if(narrow instanceof Double) {
+        if(narrow instanceof Double || narrow instanceof Float) {
             // not converting to BigDecimal, because fractional multiplication is not sensitive to precision loss
-            if(wide instanceof Double) {
-            return wide.doubleValue() * narrow.doubleValue();
-            } else {
-                return wide.floatValue() * narrow.doubleValue();
-            }
-        }
-        if(narrow instanceof Float) {
-            if(wide instanceof Double) {
-                return wide.doubleValue() * narrow.floatValue();
-            } else {
+            if (wide instanceof Float && narrow instanceof Float) {
+                // return float if both are floats
                 return wide.floatValue() * narrow.floatValue();
+            } else {
+                return wide.doubleValue() * narrow.doubleValue();
             }
         }
         

--- a/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
+++ b/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
@@ -250,7 +250,7 @@ public class DefaultNumberSystem implements NumberSystem {
             return RationalNumber.of((double)number).reciprocal();
         }
         if(number instanceof Float) {
-            return RationalNumber.of(number.doubleValue()).reciprocal();
+            return RationalNumber.of((float)number).reciprocal();
         }
         throw unsupportedNumberType(number);
     }
@@ -614,8 +614,11 @@ public class DefaultNumberSystem implements NumberSystem {
                 number instanceof Byte) {
             return BigDecimal.valueOf(number.longValue());
         }
-        if(number instanceof Double || number instanceof Float) {
+        if(number instanceof Double) {
             return BigDecimal.valueOf(number.doubleValue());
+        }
+        if(number instanceof Float) {
+            return new BigDecimal(number.toString());
         }
         if(number instanceof RationalNumber) {
             throw unexpectedCodeReach();
@@ -668,7 +671,10 @@ public class DefaultNumberSystem implements NumberSystem {
             }
             
             if(narrow instanceof Double || narrow instanceof Float) {
-                return ((BigDecimal) wide).add(BigDecimal.valueOf(narrow.doubleValue()), Calculus.MATH_CONTEXT);
+                BigDecimal addend = narrow instanceof Double
+                        ? BigDecimal.valueOf(narrow.doubleValue())
+                        : new BigDecimal(narrow.toString());
+                return ((BigDecimal) wide).add(addend, Calculus.MATH_CONTEXT);
             }
             
             if(narrow instanceof RationalNumber) {
@@ -682,27 +688,29 @@ public class DefaultNumberSystem implements NumberSystem {
         }
         
         // at this point we know, that wide is one of {Double, Float}
+        BigDecimal augend = wide instanceof Double
+                ? BigDecimal.valueOf(wide.doubleValue())
+                : new BigDecimal(wide.toString());
         
         if(narrow instanceof Double || narrow instanceof Float) {
             //converting to BigDecimal, because especially fractional addition is sensitive to precision loss
-            return BigDecimal.valueOf(wide.doubleValue())
-                .add(BigDecimal.valueOf(narrow.doubleValue()));
+            BigDecimal addend = narrow instanceof Double
+                    ? BigDecimal.valueOf(narrow.doubleValue())
+                    : new BigDecimal(narrow.toString());
+            return augend.add(addend);
         }
         
         if(narrow instanceof RationalNumber) {
             //TODO[220] can we do better than that, eg. by converting BigDecimal to RationalNumber
-            return BigDecimal.valueOf(wide.doubleValue())
-                    .add(((RationalNumber) narrow).bigDecimalValue());
+            return augend.add(((RationalNumber) narrow).bigDecimalValue());
         }
         
         if(narrow instanceof BigInteger) {
-            return BigDecimal.valueOf(wide.doubleValue())
-                    .add(new BigDecimal((BigInteger) narrow));
+            return augend.add(new BigDecimal((BigInteger) narrow));
         }
         
         // at this point we know, that 'narrow' is one of {(Atomic)Long, (Atomic)Integer, Short, Byte}
-        return BigDecimal.valueOf(wide.doubleValue())
-                .add(BigDecimal.valueOf(narrow.longValue()));
+        return augend.add(BigDecimal.valueOf(narrow.longValue()));
         
     }
     
@@ -748,7 +756,10 @@ public class DefaultNumberSystem implements NumberSystem {
             }
             
             if(narrow instanceof Double || narrow instanceof Float) {
-                return ((BigDecimal) wide).multiply(BigDecimal.valueOf(narrow.doubleValue()), Calculus.MATH_CONTEXT);
+                BigDecimal multiplier = narrow instanceof Double
+                        ? BigDecimal.valueOf(narrow.doubleValue())
+                        : new BigDecimal(narrow.toString());
+                return ((BigDecimal) wide).multiply(multiplier, Calculus.MATH_CONTEXT);
             }
             
             if(narrow instanceof RationalNumber) {
@@ -763,25 +774,37 @@ public class DefaultNumberSystem implements NumberSystem {
         
         // at this point we know, that wide is one of {Double, Float}
         
-        if(narrow instanceof Double || narrow instanceof Float) {
+        if(narrow instanceof Double) {
             // not converting to BigDecimal, because fractional multiplication is not sensitive to precision loss
+            if(wide instanceof Double) {
             return wide.doubleValue() * narrow.doubleValue();
+            } else {
+                return wide.floatValue() * narrow.doubleValue();
+            }
         }
+        if(narrow instanceof Float) {
+            if(wide instanceof Double) {
+                return wide.doubleValue() * narrow.floatValue();
+            } else {
+                return wide.floatValue() * narrow.floatValue();
+            }
+        }
+        
+        BigDecimal multiplicand = wide instanceof Double
+                ? BigDecimal.valueOf(wide.doubleValue())
+                : new BigDecimal(wide.toString());
         
         if(narrow instanceof RationalNumber) {
             //TODO[220] can we do better than that, eg. by converting BigDecimal to RationalNumber
-            return BigDecimal.valueOf(wide.doubleValue())
-                    .multiply(((RationalNumber) narrow).bigDecimalValue());
+            return multiplicand.multiply(((RationalNumber) narrow).bigDecimalValue());
         }
         
         if(narrow instanceof BigInteger) {
-            return BigDecimal.valueOf(wide.doubleValue())
-                    .multiply(new BigDecimal((BigInteger) narrow));
+            return multiplicand.multiply(new BigDecimal((BigInteger) narrow));
         }
         
         // at this point we know, that 'narrow' is one of {(Atomic)Long, (Atomic)Integer, Short, Byte}
-        return BigDecimal.valueOf(wide.doubleValue())
-                .multiply(BigDecimal.valueOf(narrow.longValue()));              
+        return multiplicand.multiply(BigDecimal.valueOf(narrow.longValue()));
      
     }
     
@@ -821,7 +844,10 @@ public class DefaultNumberSystem implements NumberSystem {
             }
             
             if(narrow instanceof Double || narrow instanceof Float) {
-                return ((BigDecimal) wide).compareTo(BigDecimal.valueOf(narrow.doubleValue()));
+                BigDecimal comparand = narrow instanceof Double
+                        ? BigDecimal.valueOf(narrow.doubleValue())
+                        : new BigDecimal(narrow.toString());
+                return ((BigDecimal) wide).compareTo(comparand);
             }
             
             if(narrow instanceof RationalNumber) {
@@ -835,25 +861,28 @@ public class DefaultNumberSystem implements NumberSystem {
         }
         
         // at this point we know, that wide is one of {Double, Float}
+        BigDecimal comparable = wide instanceof Double
+                ? BigDecimal.valueOf(wide.doubleValue())
+                : new BigDecimal(wide.toString());
         
         if(narrow instanceof Double || narrow instanceof Float) {
-            return Double.compare(wide.doubleValue(), narrow.doubleValue());
+            BigDecimal comparand = narrow instanceof Double
+                    ? BigDecimal.valueOf(narrow.doubleValue())
+                    : new BigDecimal(narrow.toString());
+            return comparable.compareTo(comparand);
         }
         
         if(narrow instanceof RationalNumber) {
             //TODO[220] can we do better than that, eg. by converting BigDecimal to RationalNumber
-            return BigDecimal.valueOf(wide.doubleValue())
-                    .compareTo(((RationalNumber) narrow).bigDecimalValue());
+            return comparable.compareTo(((RationalNumber) narrow).bigDecimalValue());
         }
         
         if(narrow instanceof BigInteger) {
-            return BigDecimal.valueOf(wide.doubleValue())
-                    .compareTo(new BigDecimal((BigInteger) narrow));
+            return comparable.compareTo(new BigDecimal((BigInteger) narrow));
         }
         
         // at this point we know, that 'narrow' is one of {(Atomic)Long, (Atomic)Integer, Short, Byte}
-        return BigDecimal.valueOf(wide.doubleValue())
-                .compareTo(BigDecimal.valueOf(narrow.longValue()));
+        return comparable.compareTo(BigDecimal.valueOf(narrow.longValue()));
         
     }
 

--- a/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
+++ b/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
@@ -247,10 +247,10 @@ public class DefaultNumberSystem implements NumberSystem {
             return ((RationalNumber) number).reciprocal();
         }
         if(number instanceof Double) {
-            return RationalNumber.of((double)number).reciprocal();
+            return RationalNumber.of(number.doubleValue()).reciprocal();
         }
         if(number instanceof Float) {
-            return RationalNumber.of((float)number).reciprocal();
+            return RationalNumber.of(number.floatValue()).reciprocal();
         }
         throw unsupportedNumberType(number);
     }

--- a/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
+++ b/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
@@ -614,10 +614,7 @@ public class DefaultNumberSystem implements NumberSystem {
                 number instanceof Byte) {
             return BigDecimal.valueOf(number.longValue());
         }
-        if(number instanceof Double) {
-            return BigDecimal.valueOf(number.doubleValue());
-        }
-        if(number instanceof Float) {
+        if(number instanceof Double || number instanceof Float) {
             return new BigDecimal(number.toString());
         }
         if(number instanceof RationalNumber) {
@@ -671,10 +668,7 @@ public class DefaultNumberSystem implements NumberSystem {
             }
             
             if(narrow instanceof Double || narrow instanceof Float) {
-                BigDecimal addend = narrow instanceof Double
-                        ? BigDecimal.valueOf(narrow.doubleValue())
-                        : new BigDecimal(narrow.toString());
-                return ((BigDecimal) wide).add(addend, Calculus.MATH_CONTEXT);
+                return ((BigDecimal) wide).add(new BigDecimal(narrow.toString()), Calculus.MATH_CONTEXT);
             }
             
             if(narrow instanceof RationalNumber) {
@@ -688,29 +682,27 @@ public class DefaultNumberSystem implements NumberSystem {
         }
         
         // at this point we know, that wide is one of {Double, Float}
-        BigDecimal augend = wide instanceof Double
-                ? BigDecimal.valueOf(wide.doubleValue())
-                : new BigDecimal(wide.toString());
         
         if(narrow instanceof Double || narrow instanceof Float) {
             //converting to BigDecimal, because especially fractional addition is sensitive to precision loss
-            BigDecimal addend = narrow instanceof Double
-                    ? BigDecimal.valueOf(narrow.doubleValue())
-                    : new BigDecimal(narrow.toString());
-            return augend.add(addend);
+            return new BigDecimal(wide.toString())
+                .add(new BigDecimal(narrow.toString()));
         }
         
         if(narrow instanceof RationalNumber) {
             //TODO[220] can we do better than that, eg. by converting BigDecimal to RationalNumber
-            return augend.add(((RationalNumber) narrow).bigDecimalValue());
+            return new BigDecimal(wide.toString())
+                    .add(((RationalNumber) narrow).bigDecimalValue());
         }
         
         if(narrow instanceof BigInteger) {
-            return augend.add(new BigDecimal((BigInteger) narrow));
+            return new BigDecimal(wide.toString())
+                    .add(new BigDecimal((BigInteger) narrow));
         }
         
         // at this point we know, that 'narrow' is one of {(Atomic)Long, (Atomic)Integer, Short, Byte}
-        return augend.add(BigDecimal.valueOf(narrow.longValue()));
+        return new BigDecimal(wide.toString())
+                .add(BigDecimal.valueOf(narrow.longValue()));
         
     }
     
@@ -756,10 +748,7 @@ public class DefaultNumberSystem implements NumberSystem {
             }
             
             if(narrow instanceof Double || narrow instanceof Float) {
-                BigDecimal multiplier = narrow instanceof Double
-                        ? BigDecimal.valueOf(narrow.doubleValue())
-                        : new BigDecimal(narrow.toString());
-                return ((BigDecimal) wide).multiply(multiplier, Calculus.MATH_CONTEXT);
+                return ((BigDecimal) wide).multiply(new BigDecimal(narrow.toString()), Calculus.MATH_CONTEXT);
             }
             
             if(narrow instanceof RationalNumber) {
@@ -790,21 +779,20 @@ public class DefaultNumberSystem implements NumberSystem {
             }
         }
         
-        BigDecimal multiplicand = wide instanceof Double
-                ? BigDecimal.valueOf(wide.doubleValue())
-                : new BigDecimal(wide.toString());
-        
         if(narrow instanceof RationalNumber) {
             //TODO[220] can we do better than that, eg. by converting BigDecimal to RationalNumber
-            return multiplicand.multiply(((RationalNumber) narrow).bigDecimalValue());
+            return new BigDecimal(wide.toString())
+                    .multiply(((RationalNumber) narrow).bigDecimalValue());
         }
         
         if(narrow instanceof BigInteger) {
-            return multiplicand.multiply(new BigDecimal((BigInteger) narrow));
+            return new BigDecimal(wide.toString())
+                    .multiply(new BigDecimal((BigInteger) narrow));
         }
         
         // at this point we know, that 'narrow' is one of {(Atomic)Long, (Atomic)Integer, Short, Byte}
-        return multiplicand.multiply(BigDecimal.valueOf(narrow.longValue()));
+        return new BigDecimal(wide.toString())
+                .multiply(BigDecimal.valueOf(narrow.longValue()));
      
     }
     
@@ -844,10 +832,7 @@ public class DefaultNumberSystem implements NumberSystem {
             }
             
             if(narrow instanceof Double || narrow instanceof Float) {
-                BigDecimal comparand = narrow instanceof Double
-                        ? BigDecimal.valueOf(narrow.doubleValue())
-                        : new BigDecimal(narrow.toString());
-                return ((BigDecimal) wide).compareTo(comparand);
+                return ((BigDecimal) wide).compareTo(new BigDecimal(narrow.toString()));
             }
             
             if(narrow instanceof RationalNumber) {
@@ -861,28 +846,26 @@ public class DefaultNumberSystem implements NumberSystem {
         }
         
         // at this point we know, that wide is one of {Double, Float}
-        BigDecimal comparable = wide instanceof Double
-                ? BigDecimal.valueOf(wide.doubleValue())
-                : new BigDecimal(wide.toString());
         
         if(narrow instanceof Double || narrow instanceof Float) {
-            BigDecimal comparand = narrow instanceof Double
-                    ? BigDecimal.valueOf(narrow.doubleValue())
-                    : new BigDecimal(narrow.toString());
-            return comparable.compareTo(comparand);
+            return new BigDecimal(wide.toString())
+			        .compareTo(new BigDecimal(narrow.toString()));
         }
         
         if(narrow instanceof RationalNumber) {
             //TODO[220] can we do better than that, eg. by converting BigDecimal to RationalNumber
-            return comparable.compareTo(((RationalNumber) narrow).bigDecimalValue());
+            return new BigDecimal(wide.toString())
+                    .compareTo(((RationalNumber) narrow).bigDecimalValue());
         }
         
         if(narrow instanceof BigInteger) {
-            return comparable.compareTo(new BigDecimal((BigInteger) narrow));
+            return new BigDecimal(wide.toString())
+                    .compareTo(new BigDecimal((BigInteger) narrow));
         }
         
         // at this point we know, that 'narrow' is one of {(Atomic)Long, (Atomic)Integer, Short, Byte}
-        return comparable.compareTo(BigDecimal.valueOf(narrow.longValue()));
+        return new BigDecimal(wide.toString())
+                .compareTo(BigDecimal.valueOf(narrow.longValue()));
         
     }
 

--- a/src/main/java/tech/units/indriya/function/RationalNumber.java
+++ b/src/main/java/tech/units/indriya/function/RationalNumber.java
@@ -124,6 +124,18 @@ public final class RationalNumber extends Number {
 	}
 
 	/**
+	 * Returns a {@code RationalNumber} that represents the given float
+	 * {@code number}, with an accuracy equivalent to {@code new BigDecimal(Float.toString(number))}.
+	 *
+	 * @param number
+	 */
+	public static RationalNumber of(float number) {
+		// smh why does Java not have BigDecimal.valueOf(float) ?!
+		final BigDecimal decimalValue = new BigDecimal(Float.toString(number));
+		return of(decimalValue);
+	}
+
+	/**
 	 * Returns a {@code RationalNumber} that represents the given BigDecimal decimalValue.
 	 * 
 	 * @param decimalValue

--- a/src/test/java/tech/units/indriya/function/DoubleMultiplyConverterTest.java
+++ b/src/test/java/tech/units/indriya/function/DoubleMultiplyConverterTest.java
@@ -53,6 +53,13 @@ public class DoubleMultiplyConverterTest {
   }
 
   @Test
+  public void testConvertMethodFloat() {
+    assertEquals(200, converter.convert(100f), 0.1);
+    assertEquals(0, converter.convert(0f));
+    assertEquals(-200, converter.convert(-100f), 0.1);
+  }
+
+  @Test
   public void testEqualityOfTwoLogConverter() {
     assertNotNull(converter);
     assertEquals(DoubleMultiplyConverter.of(2), converter);

--- a/src/test/java/tech/units/indriya/function/UnitConverterTest.java
+++ b/src/test/java/tech/units/indriya/function/UnitConverterTest.java
@@ -79,8 +79,34 @@ public class UnitConverterTest {
   }
 
   @Test
+  public void testQuantityDouble() {
+    Quantity<Length> quantLength1 = Quantities.getQuantity(1.56, sourceUnit);
+    Quantity<Length> quantResult1 = quantLength1.to(targetUnit);
+    assertNotNull(quantResult1);
+    assertNumberEquals(156, quantResult1.getValue(), 1E-12);
+    assertEquals(targetUnit, quantResult1.getUnit());
+  }
+
+  @Test
+  public void testQuantityFloat() {
+    Quantity<Length> quantLength1 = Quantities.getQuantity(1.56f, sourceUnit);
+    Quantity<Length> quantResult1 = quantLength1.to(targetUnit);
+    assertNotNull(quantResult1);
+    assertNumberEquals(156, quantResult1.getValue(), 1E-12);
+    assertEquals(targetUnit, quantResult1.getUnit());
+  }
+
+  @Test
   public void testKelvinToCelsius() {
     Quantity<Temperature> sut = Quantities.getQuantity(273.15d, KELVIN).to(CELSIUS);
+    assertNotNull(sut);
+    assertEquals(CELSIUS, sut.getUnit());
+    assertNumberEquals(0, sut.getValue(), 1E-12);
+  }
+
+  @Test
+  public void testKelvinToCelsiusFloat() {
+    Quantity<Temperature> sut = Quantities.getQuantity(273.15f, KELVIN).to(CELSIUS);
     assertNotNull(sut);
     assertEquals(CELSIUS, sut.getUnit());
     assertNumberEquals(0, sut.getValue(), 1E-12);


### PR DESCRIPTION
Fixes #329

`DefaultNumberSystem` uses `BigDecimal` to preserve floating point precision for double arithmetic, but `Float#doubleValue()` does not preserve floating point precision, leading to precision gain for float arithmetic.

- Added `RationalNumber#of(float)` to replace `RationalNumber.of(float.doubleValue())`
- Convert `Float` to `BigDecimal` using `new BigDecimal(float.toString())` instead of `BigDecimal.valueOf(float.doubleValue())` (to preserve precision)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/indriya/331)
<!-- Reviewable:end -->
