### PR TITLE
format: add option to NumberDelimiterQuantityFormat to not override NumberFormat setting

### DIFF
--- a/src/main/java/tech/units/indriya/format/NumberDelimiterQuantityFormat.java
+++ b/src/main/java/tech/units/indriya/format/NumberDelimiterQuantityFormat.java
@@ -87,6 +87,7 @@ public class NumberDelimiterQuantityFormat extends AbstractQuantityFormat {
     private String delimiter;
     private String mixDelimiter;
     private boolean localeSensitive;
+    private boolean overrideNumberFormatFractionalDigits;
 
     /** private constructor */
     private NumberDelimiterQuantityFormat() { }
@@ -102,6 +103,7 @@ public class NumberDelimiterQuantityFormat extends AbstractQuantityFormat {
         private transient String delimiter = DEFAULT_DELIMITER;
         private transient String mixedRadixDelimiter;
         private boolean localeSensitive;
+        private boolean overrideNumberFormatFractionalDigits = true;
 
         /**
          * Sets the numberFormat parameter to the given {@code NumberFormat}.
@@ -175,6 +177,18 @@ public class NumberDelimiterQuantityFormat extends AbstractQuantityFormat {
             return this;
         }
 
+        /**
+         * Sets the {@code overrideNumberFormatFractionalDigits} flag.
+         * 
+         * <p>The default is to override. Set this to false to respect the NumberFormat setting for maximum fractional digits.
+         * @param override true to override the NumberFormat setting (default), or false to respect the NumberFormat setting.
+         * @return this {@code NumberDelimiterQuantityFormat.Builder}
+         */
+        public Builder setOverrideNumberFormatFractionalDigits(boolean override) {
+            this.overrideNumberFormatFractionalDigits = override;
+            return this;
+        }
+
         public NumberDelimiterQuantityFormat build() {
             NumberDelimiterQuantityFormat quantityFormat = new NumberDelimiterQuantityFormat();
             quantityFormat.numberFormat = this.numberFormat;
@@ -183,6 +197,7 @@ public class NumberDelimiterQuantityFormat extends AbstractQuantityFormat {
             quantityFormat.delimiter = this.delimiter;
             quantityFormat.mixDelimiter = this.mixedRadixDelimiter;
             quantityFormat.localeSensitive = this.localeSensitive;
+            quantityFormat.overrideNumberFormatFractionalDigits = this.overrideNumberFormatFractionalDigits;
             return quantityFormat;
         }
     }
@@ -276,11 +291,13 @@ public class NumberDelimiterQuantityFormat extends AbstractQuantityFormat {
             }
         } else {
         */
-            if (quantity != null && quantity.getValue() != null) {
-                fract = getFractionDigitsCount(quantity.getValue().doubleValue());
-            }
-            if (fract > 1) {
-                numberFormat.setMaximumFractionDigits(fract + 1);
+            if (isOverrideNumberFormatFractionalDigits()) {
+                if (quantity != null && quantity.getValue() != null) {
+                    fract = getFractionDigitsCount(quantity.getValue().doubleValue());
+                }
+                if (fract > 1) {
+                    numberFormat.setMaximumFractionDigits(fract + 1);
+                }
             }
             dest.append(numberFormat.format(quantity.getValue()));
             if (quantity.getUnit().equals(AbstractUnit.ONE))
@@ -336,6 +353,17 @@ public class NumberDelimiterQuantityFormat extends AbstractQuantityFormat {
     @Override
     public boolean isLocaleSensitive() {
         return localeSensitive;
+    }
+
+    /**
+     * Whether to override the NumberFormat setting for fractional digits.
+     * 
+     * <p>If this is set, the NumberFormat maximumFractionDigits setting will be ignored,
+     * and all digits will be returned.
+     * @return true to override the set maximum, false to respect the NumberFormat setting.
+     */
+    public boolean isOverrideNumberFormatFractionalDigits() {
+        return overrideNumberFormatFractionalDigits;
     }
 
     @Override

--- a/src/test/java/tech/units/indriya/format/NumberDelimiterQuantityFormatTest.java
+++ b/src/test/java/tech/units/indriya/format/NumberDelimiterQuantityFormatTest.java
@@ -1,0 +1,110 @@
+/*
+ * Units of Measurement Reference Implementation
+ * Copyright (c) 2005-2021, Jean-Marie Dautelle, Werner Keil, Otavio Santana.
+ *
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions
+ *    and the following disclaimer in the documentation and/or other materials provided with the distribution.
+ *
+ * 3. Neither the name of JSR-385, Indriya nor the names of their contributors may be used to endorse or promote products
+ *    derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+ * EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+package tech.units.indriya.format;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
+
+import javax.measure.Quantity;
+
+import org.junit.jupiter.api.Test;
+
+import tech.units.indriya.quantity.Quantities;
+import tech.units.indriya.unit.Units;
+
+/**
+ * @author Brad Hards
+ *
+ */
+public class NumberDelimiterQuantityFormatTest {
+    private final Quantity<?> quantityInteger = Quantities.getQuantity(Short.valueOf("10"), Units.CELSIUS);
+    private final Quantity<?> quantityWithDecimals = Quantities.getQuantity(Double.valueOf("10.123"), Units.CELSIUS);
+
+    @Test
+    public void testFormatDefaultInstance() {
+        NumberDelimiterQuantityFormat uut = NumberDelimiterQuantityFormat.getInstance();
+        assertEquals(uut.format(quantityInteger), "10 ℃");
+        assertEquals(uut.format(quantityWithDecimals), "10.123 ℃");
+    }
+
+    @Test
+    public void testFormatNumberFormatInstance() {
+        NumberFormat numberFormat = new DecimalFormat();
+        numberFormat.setMinimumFractionDigits(2); // used
+        numberFormat.setMaximumFractionDigits(2); // ignored
+        NumberDelimiterQuantityFormat uut = NumberDelimiterQuantityFormat.getInstance(numberFormat, SimpleUnitFormat.getInstance());
+        assertEquals(uut.format(quantityInteger), "10.00 ℃");
+        assertEquals(uut.format(quantityWithDecimals), "10.123 ℃");
+    }
+
+    @Test
+    public void testFormatBuilderOverrideDefault() {
+        NumberFormat numberFormat = new DecimalFormat();
+        numberFormat.setMinimumFractionDigits(2); // used
+        numberFormat.setMaximumFractionDigits(2); // ignored
+        NumberDelimiterQuantityFormat uut = new NumberDelimiterQuantityFormat.Builder()
+            .setNumberFormat(numberFormat)
+            .setUnitFormat(SimpleUnitFormat.getInstance())
+            .build();
+        assertEquals(uut.format(quantityInteger), "10.00 ℃");
+        assertEquals(uut.format(quantityWithDecimals), "10.123 ℃");
+    }
+
+    @Test
+    public void testFormatBuilderOverrideExplicit() {
+        NumberFormat numberFormat = new DecimalFormat();
+        numberFormat.setMinimumFractionDigits(2); // used
+        numberFormat.setMaximumFractionDigits(2); // ignored
+        NumberDelimiterQuantityFormat uut = new NumberDelimiterQuantityFormat.Builder()
+            .setNumberFormat(numberFormat)
+            .setUnitFormat(SimpleUnitFormat.getInstance())
+            .setOverrideNumberFormatFractionalDigits(true)
+            .build();
+        assertEquals(uut.format(quantityInteger), "10.00 ℃");
+        assertEquals(uut.format(quantityWithDecimals), "10.123 ℃");
+    }
+
+    @Test
+    public void testFormatBuilderNoOverrideMinDigits() {
+        NumberFormat numberFormat = new DecimalFormat();
+        numberFormat.setMinimumFractionDigits(2);
+        numberFormat.setMaximumFractionDigits(2);
+        NumberDelimiterQuantityFormat uut = new NumberDelimiterQuantityFormat.Builder()
+            .setNumberFormat(numberFormat)
+            .setUnitFormat(SimpleUnitFormat.getInstance())
+            .setOverrideNumberFormatFractionalDigits(false)
+            .build();
+        assertEquals(uut.format(quantityInteger), "10.00 ℃");
+        assertEquals(uut.format(quantityWithDecimals), "10.12 ℃");
+    }
+
+}


### PR DESCRIPTION
#358 identifies an issue with `NumberDelimiterQuantityFormat` overriding the precision set in the composed `NumberFormat`. That looks like it is intended behaviour (i.e. there is a bunch of additional code to make that happen). However it is not always desired (as shown in #358).

The attached patch makes that optional via a builder setting. Additional options are undesirable, but in this case I can't see another way to keep the current behaviour for backwards compatibility and to support the required use case. For backwards compatibility, the option defaults to the current behaviour. 

There are additional unit tests to verify it works as stated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/indriya/364)
<!-- Reviewable:end -->
