### PR TITLE
Make static caching hash maps multithreading safe

### DIFF
--- a/src/main/java/tech/units/indriya/function/Calculus.java
+++ b/src/main/java/tech/units/indriya/function/Calculus.java
@@ -39,6 +39,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -122,7 +123,7 @@ public final class Calculus {
 	/**
 	 * Memoization of Pi by number-of-digits.
 	 */
-	private static final Map<Integer, BigDecimal> piCache = new HashMap<>();
+	private static final Map<Integer, BigDecimal> piCache = new ConcurrentHashMap<>();
 	
 	/**
 	 * Pi calculation with Machin's formula.

--- a/src/main/java/tech/units/indriya/quantity/DefaultQuantityFactory.java
+++ b/src/main/java/tech/units/indriya/quantity/DefaultQuantityFactory.java
@@ -62,7 +62,6 @@ import static tech.units.indriya.unit.Units.VOLT;
 import static tech.units.indriya.unit.Units.WATT;
 import static tech.units.indriya.unit.Units.WEBER;
 
-import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -98,7 +97,7 @@ import tech.units.indriya.AbstractUnit;
  */
 public class DefaultQuantityFactory<Q extends Quantity<Q>> implements QuantityFactory<Q> {
     @SuppressWarnings("rawtypes")
-    static final Map<Class, QuantityFactory> INSTANCES = new HashMap<>();
+    static final Map<Class, QuantityFactory> INSTANCES = new ConcurrentHashMap<>();
 
     static final Logger LOGGER = Logger.getLogger(DefaultQuantityFactory.class.getName());
 
@@ -189,7 +188,7 @@ public class DefaultQuantityFactory<Q extends Quantity<Q>> implements QuantityFa
             throw new ClassCastException();
         }
         factory = new DefaultQuantityFactory<Q>(type);
-        INSTANCES.put(type, factory);
+        INSTANCES.putIfAbsent(type, factory);
         return factory;
     }
 


### PR DESCRIPTION
Two static hash maps that are use for caching values were not
multithreading safe.

We change their type from `HashMap` to `ConcurrentHashMap` to avoid
synchronization issues.

Fixes #371

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/indriya/372)
<!-- Reviewable:end -->
