### PR TITLE
(#393) DefaultNumberSystem: slight performance improvements

### DIFF
--- a/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
+++ b/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
@@ -164,7 +164,7 @@ public class DefaultNumberSystem implements NumberSystem {
          * Whether given {@link Number} is ZERO.
          * @param number - must be of type {@link #getType()}
          * @apiNote For class internal use only, 
-         *      such that we have control over the number's type that gets past in.
+         *      such that we have control over the number's type that gets passed in.
          */
         boolean isZero(Number number) {
             return zero.equals(number);

--- a/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
+++ b/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
@@ -861,10 +861,12 @@ public class DefaultNumberSystem implements NumberSystem {
 
     }
 
-
+    /**
+     * @param unusedNarrowType - currently unused (but future refactoring might use it)
+     */
     private int compareWideVsNarrow(
             final NumberType wideType, final Number wide,
-            final NumberType narrowType, final Number narrow) {
+            final NumberType unusedNarrowType, final Number narrow) {
 
         if(wideType.isIntegerOnly()) {
             // at this point we know, that narrow must also be an integer-only type

--- a/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
+++ b/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
@@ -775,6 +775,12 @@ public class DefaultNumberSystem implements NumberSystem {
     private Number multiplyWideAndNarrow(
             final NumberType wideType, final Number wide,
             final NumberType narrowType, final Number narrow) {
+        
+        // shortcut if any of the operands is zero.
+        if (wideType.isZero(wide)
+                || narrowType.isZero(narrow)) {
+            return 0;
+        }
 
         if(wideType.isIntegerOnly()) {
             // at this point we know, that narrow must also be an integer-only type

--- a/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
+++ b/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
@@ -41,19 +41,19 @@ import tech.units.indriya.spi.NumberSystem;
 
 /**
  * {@link NumberSystem} implementation to support Java's built-in {@link Number}s and the
- * {@link RationalNumber} type.   
- * 
+ * {@link RationalNumber} type.
+ *
  * @author Andi Huber
  * @author Werner Keil
  * @since 2.0
  */
 public class DefaultNumberSystem implements NumberSystem {
-    
+
     /**
      *  In order of increasing number type 'widening'.
      */
     private enum NumberType {
-        
+
         // integer types
         BYTE_BOXED(true, Byte.class, (byte)1, (byte)0),
         SHORT_BOXED(true, Short.class, (short)1, (short)0),
@@ -62,24 +62,24 @@ public class DefaultNumberSystem implements NumberSystem {
         LONG_BOXED(true, Long.class, 1L, 0L),
         LONG_ATOMIC(true, AtomicLong.class, 1L, 0),
         BIG_INTEGER(true, BigInteger.class, BigInteger.ONE, BigInteger.ZERO),
-        
+
         // rational types
         RATIONAL(false, RationalNumber.class, RationalNumber.ONE, RationalNumber.ZERO),
-        
+
         // fractional types
         FLOAT_BOXED(false, Float.class, 1.f, 0.f),
         DOUBLE_BOXED(false, Double.class, 1.d, 0.d),
         BIG_DECIMAL(false, BigDecimal.class, BigDecimal.ONE, BigDecimal.ZERO),
-        
+
         ;
         private final boolean integerOnly;
         private final Class<? extends Number> type;
         private final Number one;
         private final Number zero;
-        
-        private NumberType(boolean integerOnly, Class<? extends Number> type, 
-                Number one, Number zero) {
-            
+
+        private NumberType(final boolean integerOnly, final Class<? extends Number> type,
+                final Number one, final Number zero) {
+
             this.integerOnly = integerOnly;
             this.type = type;
             this.one = one;
@@ -94,19 +94,19 @@ public class DefaultNumberSystem implements NumberSystem {
         public boolean isIntegerOnly() {
             return integerOnly;
         }
-        
+
         @SuppressWarnings("unused")
         public Class<? extends Number> getType() {
             return type;
         }
 
         // 'hardcoded' for performance reasons
-        static NumberType valueOf(Number number) {
+        static NumberType valueOf(final Number number) {
             if(number instanceof Long) {
-                return LONG_BOXED; 
+                return LONG_BOXED;
             }
             if(number instanceof AtomicLong) {
-                return LONG_ATOMIC; 
+                return LONG_ATOMIC;
             }
             if(number instanceof Integer) {
                 return INTEGER_BOXED;
@@ -139,51 +139,51 @@ public class DefaultNumberSystem implements NumberSystem {
                     number.getClass().getName());
             throw new IllegalArgumentException(msg);
         }
-        
+
     }
 
     @Override
-    public Number add(Number x, Number y) {
-        
+    public Number add(final Number x, final Number y) {
+
         final NumberType type_x = NumberType.valueOf(x);
         final NumberType type_y = NumberType.valueOf(y);
-        
+
         final boolean reorder_args = type_y.ordinal()>type_x.ordinal();
-        
+
         return reorder_args
                 ? addWideAndNarrow(type_y, y, type_x, x)
-                        : addWideAndNarrow(type_x, x, type_y, y);
+                : addWideAndNarrow(type_x, x, type_y, y);
     }
 
     @Override
-    public Number subtract(Number x, Number y) {
+    public Number subtract(final Number x, final Number y) {
         return add(x, negate(y));
     }
 
     @Override
-    public Number multiply(Number x, Number y) {
-        
+    public Number multiply(final Number x, final Number y) {
+
         final NumberType type_x = NumberType.valueOf(x);
         final NumberType type_y = NumberType.valueOf(y);
-        
+
         final boolean reorder_args = type_y.ordinal()>type_x.ordinal();
-        
+
         return reorder_args
                 ? multiplyWideAndNarrow(type_y, y, type_x, x)
-                        : multiplyWideAndNarrow(type_x, x, type_y, y);
+                : multiplyWideAndNarrow(type_x, x, type_y, y);
     }
 
     @Override
-    public Number divide(Number x, Number y) {
+    public Number divide(final Number x, final Number y) {
         return multiply(x, reciprocal(y));
     }
-    
+
     @Override
-    public Number[] divideAndRemainder(Number x, Number y, boolean roundRemainderTowardsZero) {
-        
+    public Number[] divideAndRemainder(final Number x, final Number y, final boolean roundRemainderTowardsZero) {
+
         final int sign_x = signum(x);
         final int sign_y = signum(y);
-        
+
         final int sign = sign_x * sign_y;
         // handle corner cases when x or y are zero
         if(sign == 0) {
@@ -194,55 +194,55 @@ public class DefaultNumberSystem implements NumberSystem {
                 return new Number[] {0, 0};
             }
         }
-        
+
         final Number absX = abs(x);
         final Number absY = abs(y);
-        
+
         final NumberType type_x = NumberType.valueOf(absX);
         final NumberType type_y = NumberType.valueOf(absY);
-        
+
         // if x and y are both integer types than we can calculate integer results,
         // otherwise we resort to BigDecimal
         final boolean yieldIntegerResult = type_x.isIntegerOnly() && type_y.isIntegerOnly();
-        
+
         if(yieldIntegerResult) {
-                            
+
             final BigInteger integer_x = integerToBigInteger(absX);
             final BigInteger integer_y = integerToBigInteger(absY);
-            
+
             final BigInteger[] divAndRemainder = integer_x.divideAndRemainder(integer_y);
-            
+
             return applyToArray(divAndRemainder, number->copySignTo(sign, (BigInteger)number));
-            
+
         } else {
-            
-            final MathContext mathContext = 
+
+            final MathContext mathContext =
                     new MathContext(Calculus.MATH_CONTEXT.getPrecision(), RoundingMode.FLOOR);
-            
+
             final BigDecimal decimal_x = (type_x == NumberType.RATIONAL)
                     ? ((RationalNumber) absX).bigDecimalValue()
                             : toBigDecimal(absX);
             final BigDecimal decimal_y = (type_y == NumberType.RATIONAL)
                     ? ((RationalNumber) absY).bigDecimalValue()
                             : toBigDecimal(absY);
-            
+
             final BigDecimal[] divAndRemainder = decimal_x.divideAndRemainder(decimal_y, mathContext);
-            
+
             if(roundRemainderTowardsZero) {
                 return new Number[] {
-                        copySignTo(sign, divAndRemainder[0]), 
+                        copySignTo(sign, divAndRemainder[0]),
                         copySignTo(sign, divAndRemainder[1].toBigInteger())};
-                
+
             } else {
                 return applyToArray(divAndRemainder, number->copySignTo(sign, (BigDecimal)number));
             }
-            
+
         }
 
     }
 
     @Override
-    public Number reciprocal(Number number) {
+    public Number reciprocal(final Number number) {
         if(isIntegerOnly(number)) {
             return RationalNumber.of(BigInteger.ONE, integerToBigInteger(number));
         }
@@ -262,7 +262,7 @@ public class DefaultNumberSystem implements NumberSystem {
     }
 
     @Override
-    public int signum(Number number) {
+    public int signum(final Number number) {
         if(number instanceof BigInteger) {
             return ((BigInteger) number).signum();
         }
@@ -287,11 +287,11 @@ public class DefaultNumberSystem implements NumberSystem {
             final int intValue = number.intValue();
             return Integer.signum(intValue);
         }
-        throw unsupportedNumberType(number);    
+        throw unsupportedNumberType(number);
     }
-    
+
     @Override
-    public Number abs(Number number) {
+    public Number abs(final Number number) {
         if(number instanceof BigInteger) {
             return ((BigInteger) number).abs();
         }
@@ -324,11 +324,11 @@ public class DefaultNumberSystem implements NumberSystem {
         if(number instanceof Short || number instanceof Byte) {
             Math.abs(number.intValue()); // widen to int
         }
-        throw unsupportedNumberType(number);    
+        throw unsupportedNumberType(number);
     }
-    
+
     @Override
-    public Number negate(Number number) {
+    public Number negate(final Number number) {
         if(number instanceof BigInteger) {
             return ((BigInteger) number).negate();
         }
@@ -374,9 +374,9 @@ public class DefaultNumberSystem implements NumberSystem {
         }
         throw unsupportedNumberType(number);
     }
-    
+
     @Override
-    public Number power(Number number, int exponent) {
+    public Number power(final Number number, final int exponent) {
         if(exponent==0) {
             if(isZero(number)) {
                 throw new ArithmeticException("0^0 is not defined");
@@ -392,10 +392,10 @@ public class DefaultNumberSystem implements NumberSystem {
                 number instanceof Short || number instanceof Byte) {
             final BigInteger bigInt = integerToBigInteger(number);
             if(exponent>0) {
-                return bigInt.pow(exponent);    
+                return bigInt.pow(exponent);
             }
             return RationalNumber.ofInteger(bigInt).pow(exponent);
-            
+
         }
         if(number instanceof BigDecimal) {
             return ((BigDecimal) number).pow(exponent, Calculus.MATH_CONTEXT);
@@ -408,29 +408,29 @@ public class DefaultNumberSystem implements NumberSystem {
         }
         throw unsupportedNumberType(number);
     }
-    
+
     @Override
-    public Number exp(Number number) {
-        //TODO[220] this is a poor implementation, certainly we can do better using BigDecimal 
+    public Number exp(final Number number) {
+        //TODO[220] this is a poor implementation, certainly we can do better using BigDecimal
         return Math.exp(number.doubleValue());
     }
-    
+
     @Override
-    public Number log(Number number) {
+    public Number log(final Number number) {
         //TODO[220] this is a poor implementation, certainly we can do better using BigDecimal
         return Math.log(number.doubleValue());
     }
-    
+
     @Override
-    public Number narrow(Number number) {
-        
+    public Number narrow(final Number number) {
+
         //Implementation Note: for performance we stop narrowing down at 'double' or 'integer' level
-        
+
         if(number instanceof Integer || number instanceof AtomicInteger ||
                 number instanceof Short || number instanceof Byte) {
             return number;
         }
-        
+
         if(number instanceof Double || number instanceof Float) {
             final double doubleValue = number.doubleValue();
             if(!Double.isFinite(doubleValue)) {
@@ -442,47 +442,49 @@ public class DefaultNumberSystem implements NumberSystem {
             }
             return number;
         }
-        
+
         if(isIntegerOnly(number)) {
-            
+
             // number is one of {BigInteger, Long}
-            
+
             final int total_bits_required = bitLengthOfInteger(number);
-            
+
             // check whether we have enough bits to store the result into an int
-            if(total_bits_required<31) { 
+            if(total_bits_required<31) {
                 return number.intValue();
             }
-            
+
             // check whether we have enough bits to store the result into a long
-            if(total_bits_required<63) { 
+            if(total_bits_required<63) {
                 return number.longValue();
             }
-            
+
             return number; // cannot narrow down
-            
+
         }
 
         if(number instanceof BigDecimal) {
-            
+
             final BigDecimal decimal = (BigDecimal) number;
-            //TODO once we have a fast check, activate this here
-//            if(isFractional(decimal)) {
-//                return number; // cannot narrow to integer
-//            }
-            try {
-                BigInteger integer = decimal.toBigIntegerExact(); 
-                return narrow(integer);
-            } catch (ArithmeticException e) {
+            // educated guess: it is more likely for the given decimal to have fractional parts, than not;
+            // hence in order to avoid the expensive conversion attempt decimal.toBigIntegerExact() below,
+            // we do a less expensive check first
+            if(isFractional(decimal)) {
                 return number; // cannot narrow to integer
             }
+            try {
+                BigInteger integer = decimal.toBigIntegerExact();
+                return narrow(integer);
+            } catch (ArithmeticException e) {
+                return number; // cannot narrow to integer (unexpected code reach, due to isFractional(decimal) guard above)
+            }
         }
-        
+
         if(number instanceof RationalNumber) {
-            
+
             final RationalNumber rational = ((RationalNumber) number);
-            
-            return rational.isInteger() 
+
+            return rational.isInteger()
                     ? narrow(rational.getDividend()) // divisor is ONE
                             : number; // cannot narrow to integer;
         }
@@ -490,87 +492,87 @@ public class DefaultNumberSystem implements NumberSystem {
         // for any other number type just do nothing
         return number;
     }
-    
+
     @Override
-    public int compare(Number x, Number y) {
-        
+    public int compare(final Number x, final Number y) {
+
         final NumberType type_x = NumberType.valueOf(x);
         final NumberType type_y = NumberType.valueOf(y);
-        
+
         final boolean reorder_args = type_y.ordinal()>type_x.ordinal();
-        
+
         return reorder_args
                 ? -compareWideVsNarrow(type_y, y, type_x, x)
                         : compareWideVsNarrow(type_x, x, type_y, y);
     }
-    
+
     @Override
-    public boolean isZero(Number number) {
+    public boolean isZero(final Number number) {
         NumberType numberType = NumberType.valueOf(number);
         return compare(numberType.zero, number) == 0;
     }
 
     @Override
-    public boolean isOne(Number number) {
+    public boolean isOne(final Number number) {
         NumberType numberType = NumberType.valueOf(number);
         return compare(numberType.one, number) == 0;
     }
-    
+
     @Override
-    public boolean isLessThanOne(Number number) {
+    public boolean isLessThanOne(final Number number) {
         NumberType numberType = NumberType.valueOf(number);
         return compare(numberType.one, number) > 0;
     }
-     
+
     @Override
-    public boolean isInteger(Number number) {
+    public boolean isInteger(final Number number) {
         NumberType numberType = NumberType.valueOf(number);
         return isInteger(numberType, number);
     }
-    
-    
+
+
     // -- HELPER
-    
-    private IllegalArgumentException unsupportedNumberValue(Number number) {
+
+    private IllegalArgumentException unsupportedNumberValue(final Number number) {
         final String msg = String.format("Unsupported number value '%s' of type '%s' in number system '%s'",
                 "" + number,
                 number.getClass(),
                 this.getClass().getName());
-        
+
         return new IllegalArgumentException(msg);
     }
-    
-    private IllegalArgumentException unsupportedNumberType(Number number) {
+
+    private IllegalArgumentException unsupportedNumberType(final Number number) {
         final String msg = String.format("Unsupported number type '%s' in number system '%s'",
                 number.getClass().getName(),
                 this.getClass().getName());
-        
+
         return new IllegalArgumentException(msg);
     }
-    
+
     private IllegalStateException unexpectedCodeReach() {
         final String msg = String.format("Implementation Error: Code was reached that is expected unreachable");
         return new IllegalStateException(msg);
     }
-    
+
     /**
      * Whether the {@link Number}'s type can only represent integers.
      * <p>
      * If <code>false</code> it can also represent fractional numbers.
-     * <p> 
-     * Note: this does not check whether given number represents an integer. 
+     * <p>
+     * Note: this does not check whether given number represents an integer.
      */
-    private boolean isIntegerOnly(Number number) {
+    private boolean isIntegerOnly(final Number number) {
         return NumberType.valueOf(number).isIntegerOnly();
     }
-    
+
     /**
-     * Whether given {@link BigDecimal} has (non-zero) fractional parts. 
+     * Whether given {@link BigDecimal} has (non-zero) fractional parts.
      * When <code>false</code>, given {@link BigDecimal} can be converted to a {@link BigInteger}.
      * @implNote {@link BigDecimal#stripTrailingZeros()} creates a new {@link BigDecimal} just to do the check.
      * @see https://stackoverflow.com/questions/1078953/check-if-bigdecimal-is-integer-value
      */
-    static boolean isFractional(BigDecimal decimal) {
+    static boolean isFractional(final BigDecimal decimal) {
         // check if is ZERO first
         if(decimal.signum() == 0) {
             return false;
@@ -579,25 +581,25 @@ public class DefaultNumberSystem implements NumberSystem {
         if(decimal.scale()<=0) {
             return false;
         }
-        // Note: this creates a new BigDecimal instance just to check for fractional parts 
+        // Note: this creates a new BigDecimal instance just to check for fractional parts
         // (perhaps we can improve that in the future)
         return decimal.stripTrailingZeros().scale() > 0;
     }
-    
+
     /**
-     * Whether given {@link Number} represents an integer. 
-     * Optimized for when we know the {@link NumberType} in advance.  
+     * Whether given {@link Number} represents an integer.
+     * Optimized for when we know the {@link NumberType} in advance.
      */
-    private boolean isInteger(NumberType numberType, Number number) {
+    private boolean isInteger(final NumberType numberType, final Number number) {
         if(numberType.isIntegerOnly()) {
             return true; // numberType only allows integer
         }
         if(number instanceof RationalNumber) {
             return ((RationalNumber)number).isInteger();
         }
-        
+
         // remaining types to check: Double, Float, BigDecimal ...
-        
+
         if(number instanceof BigDecimal) {
             return !isFractional((BigDecimal)number);
         }
@@ -605,17 +607,17 @@ public class DefaultNumberSystem implements NumberSystem {
             double doubleValue = number.doubleValue();
             // see https://stackoverflow.com/questions/15963895/how-to-check-if-a-double-value-has-no-decimal-part
             if (isZero(number)) return false;
-            return doubleValue % 1 == 0; 
+            return doubleValue % 1 == 0;
         }
         throw unsupportedNumberType(number);
     }
-    
-    private int bitLengthOfInteger(Number number) {
+
+    private int bitLengthOfInteger(final Number number) {
         if(number instanceof BigInteger) {
             return ((BigInteger) number).bitLength();
         }
-        long long_value = number.longValue(); 
-        
+        long long_value = number.longValue();
+
         if(long_value == Long.MIN_VALUE) {
             return 63;
         } else {
@@ -623,26 +625,26 @@ public class DefaultNumberSystem implements NumberSystem {
             return 64-leadingZeros;
         }
     }
-    
-    private BigInteger integerToBigInteger(Number number) {
+
+    private BigInteger integerToBigInteger(final Number number) {
         if(number instanceof BigInteger) {
             return (BigInteger) number;
         }
         return BigInteger.valueOf(number.longValue());
     }
-    
-    private BigDecimal toBigDecimal(Number number) {
+
+    private BigDecimal toBigDecimal(final Number number) {
         if(number instanceof BigDecimal) {
             return (BigDecimal) number;
         }
         if(number instanceof BigInteger) {
             return new BigDecimal((BigInteger) number);
         }
-        if(number instanceof Long || 
+        if(number instanceof Long ||
                 number instanceof AtomicLong ||
-                number instanceof Integer || 
+                number instanceof Integer ||
                 number instanceof AtomicInteger ||
-                number instanceof Short || 
+                number instanceof Short ||
                 number instanceof Byte) {
             return BigDecimal.valueOf(number.longValue());
         }
@@ -652,277 +654,277 @@ public class DefaultNumberSystem implements NumberSystem {
         if(number instanceof RationalNumber) {
             throw unexpectedCodeReach();
             //Note: don't do that (potential precision loss)
-            //return ((RationalNumber) number).bigDecimalValue(); 
+            //return ((RationalNumber) number).bigDecimalValue();
         }
         throw unsupportedNumberType(number);
     }
 
     private Number addWideAndNarrow(
-            NumberType wideType, Number wide, 
-            NumberType narrowType, Number narrow) {
-        
-        // avoid type-check or widening if one of the arguments is zero 
+            final NumberType wideType, final Number wide,
+            final NumberType narrowType, final Number narrow) {
+
+        // avoid type-check or widening if one of the arguments is zero
         // https://github.com/unitsofmeasurement/indriya/issues/384
         if (isZero(wide)) {
             return narrow;
         } else if (isZero(narrow)) {
             return wide;
         }
-        
+
         if(wideType.isIntegerOnly()) {
             // at this point we know, that narrow must also be an integer-only type
             if(wide instanceof BigInteger) {
                 return ((BigInteger) wide).add(integerToBigInteger(narrow));
             }
-            
+
             // at this point we know, that 'wide' and 'narrow' are one of {(Atomic)Long, (Atomic)Integer, Short, Byte}
-            
+
             // +1 carry, not including sign
-            int total_bits_required = Math.max(bitLengthOfInteger(wide), bitLengthOfInteger(narrow)) + 1; 
-            
+            int total_bits_required = Math.max(bitLengthOfInteger(wide), bitLengthOfInteger(narrow)) + 1;
+
             // check whether we have enough bits to store the result into a long
-            if(total_bits_required<63) { 
+            if(total_bits_required<63) {
                 return wide.longValue() + narrow.longValue();
             }
-            
+
             return integerToBigInteger(wide).add(integerToBigInteger(narrow));
         }
-        
+
         if(wide instanceof RationalNumber) {
-            
+
             // at this point we know, that narrow must either be rational or an integer-only type
             if(narrow instanceof RationalNumber) {
                 return ((RationalNumber) wide).add((RationalNumber) narrow);
             }
-            
+
             return ((RationalNumber) wide).add(
                     RationalNumber.ofInteger(integerToBigInteger(narrow)));
         }
-        
+
         // at this point we know, that wide is one of {BigDecimal, Double, Float}
-        
+
         if(wide instanceof BigDecimal) {
-            
+
             if(narrow instanceof BigDecimal) {
                 return ((BigDecimal) wide).add((BigDecimal) narrow, Calculus.MATH_CONTEXT);
             }
-            
+
             if(narrow instanceof Double || narrow instanceof Float) {
                 return ((BigDecimal) wide).add(BigDecimal.valueOf(narrow.doubleValue()), Calculus.MATH_CONTEXT);
             }
-            
+
             if(narrow instanceof RationalNumber) {
-                //TODO[220] can we do better than that, eg. by converting BigDecimal to RationalNumber 
+                //TODO[220] can we do better than that, eg. by converting BigDecimal to RationalNumber
                 return ((BigDecimal) wide).add(((RationalNumber) narrow).bigDecimalValue());
             }
-            
+
             // at this point we know, that 'narrow' is one of {(Atomic)Long, (Atomic)Integer, Short, Byte}
             return ((BigDecimal) wide).add(BigDecimal.valueOf(narrow.longValue()));
-            
+
         }
-        
+
         // at this point we know, that wide is one of {Double, Float}
-        
+
         if(narrow instanceof Double || narrow instanceof Float) {
             //converting to BigDecimal, because especially fractional addition is sensitive to precision loss
             return BigDecimal.valueOf(wide.doubleValue())
                 .add(BigDecimal.valueOf(narrow.doubleValue()));
         }
-        
+
         if(narrow instanceof RationalNumber) {
             //TODO[220] can we do better than that, eg. by converting BigDecimal to RationalNumber
             return BigDecimal.valueOf(wide.doubleValue())
                     .add(((RationalNumber) narrow).bigDecimalValue());
         }
-        
+
         if(narrow instanceof BigInteger) {
             return BigDecimal.valueOf(wide.doubleValue())
                     .add(new BigDecimal((BigInteger) narrow));
         }
-        
+
         // at this point we know, that 'narrow' is one of {(Atomic)Long, (Atomic)Integer, Short, Byte}
         return BigDecimal.valueOf(wide.doubleValue())
                 .add(BigDecimal.valueOf(narrow.longValue()));
-        
+
     }
-    
+
     private Number multiplyWideAndNarrow(
-            NumberType wideType, Number wide, 
-            NumberType narrowType, Number narrow) {
-        
+            final NumberType wideType, final Number wide,
+            final NumberType narrowType, final Number narrow) {
+
         if(wideType.isIntegerOnly()) {
             // at this point we know, that narrow must also be an integer-only type
             if(wide instanceof BigInteger) {
                 return ((BigInteger) wide).multiply(integerToBigInteger(narrow));
             }
-            
+
             // at this point we know, that 'wide' and 'narrow' are one of {(Atomic)Long, (Atomic)Integer, Short, Byte}
-            
+
             int total_bits_required = bitLengthOfInteger(wide) + bitLengthOfInteger(narrow); // not including sign
-            
+
             // check whether we have enough bits to store the result into a long
-            if(total_bits_required<63) { 
+            if(total_bits_required<63) {
                 return wide.longValue() * narrow.longValue();
             }
-            
+
             return integerToBigInteger(wide).multiply(integerToBigInteger(narrow));
         }
-        
+
         if(wide instanceof RationalNumber) {
-            
+
             // at this point we know, that narrow must either be rational or an integer-only type
             if(narrow instanceof RationalNumber) {
                 return ((RationalNumber) wide).multiply((RationalNumber) narrow);
             }
-            
+
             return ((RationalNumber) wide).multiply(
                     RationalNumber.ofInteger(integerToBigInteger(narrow)));
         }
-        
+
         // at this point we know, that wide is one of {BigDecimal, Double, Float}
-        
+
         if(wide instanceof BigDecimal) {
-            
+
             if(narrow instanceof BigDecimal) {
                 return ((BigDecimal) wide).multiply((BigDecimal) narrow, Calculus.MATH_CONTEXT);
             }
-            
+
             if(narrow instanceof BigInteger) {
                 return ((BigDecimal) wide).multiply(new BigDecimal((BigInteger)narrow), Calculus.MATH_CONTEXT);
             }
-            
+
             if(narrow instanceof Double || narrow instanceof Float) {
                 return ((BigDecimal) wide).multiply(BigDecimal.valueOf(narrow.doubleValue()), Calculus.MATH_CONTEXT);
             }
-            
+
             if(narrow instanceof RationalNumber) {
-                //TODO[220] can we do better than that, eg. by converting BigDecimal to RationalNumber 
+                //TODO[220] can we do better than that, eg. by converting BigDecimal to RationalNumber
                 return ((BigDecimal) wide).multiply(((RationalNumber) narrow).bigDecimalValue());
             }
-            
+
             // at this point we know, that 'narrow' is one of {(Atomic)Long, (Atomic)Integer, Short, Byte}
             return ((BigDecimal) wide).multiply(BigDecimal.valueOf(narrow.longValue()));
-            
+
         }
-        
+
         // at this point we know, that wide is one of {Double, Float}
-        
+
         if(narrow instanceof Double || narrow instanceof Float) {
             // not converting to BigDecimal, because fractional multiplication is not sensitive to precision loss
             return wide.doubleValue() * narrow.doubleValue();
         }
-        
+
         if(narrow instanceof RationalNumber) {
             //TODO[220] can we do better than that, eg. by converting BigDecimal to RationalNumber
             return BigDecimal.valueOf(wide.doubleValue())
                     .multiply(((RationalNumber) narrow).bigDecimalValue());
         }
-        
+
         if(narrow instanceof BigInteger) {
             return BigDecimal.valueOf(wide.doubleValue())
                     .multiply(new BigDecimal((BigInteger) narrow));
         }
-        
+
         // at this point we know, that 'narrow' is one of {(Atomic)Long, (Atomic)Integer, Short, Byte}
         return BigDecimal.valueOf(wide.doubleValue())
-                .multiply(BigDecimal.valueOf(narrow.longValue()));              
-     
+                .multiply(BigDecimal.valueOf(narrow.longValue()));
+
     }
-    
-    
+
+
     private int compareWideVsNarrow(
-            NumberType wideType, Number wide, 
-            NumberType narrowType, Number narrow) {
-        
-        
+            final NumberType wideType, final Number wide,
+            final NumberType narrowType, final Number narrow) {
+
+
         if(wideType.isIntegerOnly()) {
             // at this point we know, that narrow must also be an integer-only type
             if(wide instanceof BigInteger) {
                 return ((BigInteger) wide).compareTo(integerToBigInteger(narrow));
             }
-            
+
             // at this point we know, that 'wide' and 'narrow' are one of {(Atomic)Long, (Atomic)Integer, Short, Byte}
             return Long.compare(wide.longValue(), narrow.longValue());
         }
-        
+
         if(wide instanceof RationalNumber) {
-            
+
             // at this point we know, that narrow must either be rational or an integer-only type
             if(narrow instanceof RationalNumber) {
                 return ((RationalNumber) wide).compareTo((RationalNumber) narrow);
             }
-            
+
             return ((RationalNumber) wide).compareTo(
                     RationalNumber.ofInteger(integerToBigInteger(narrow)));
         }
-        
+
         // at this point we know, that wide is one of {BigDecimal, Double, Float}
-        
+
         if(wide instanceof BigDecimal) {
-            
+
             if(narrow instanceof BigDecimal) {
                 return ((BigDecimal) wide).compareTo((BigDecimal) narrow);
             }
-            
+
             if(narrow instanceof Double || narrow instanceof Float) {
                 return ((BigDecimal) wide).compareTo(BigDecimal.valueOf(narrow.doubleValue()));
             }
-            
+
             if(narrow instanceof RationalNumber) {
                 //TODO[220] can we do better than that, eg. by converting BigDecimal to RationalNumber
                 return ((BigDecimal) wide).compareTo(((RationalNumber) narrow).bigDecimalValue());
             }
-            
+
             if (narrow instanceof BigInteger) {
                 //TODO for optimization, can this be done without instantiating a new BigDecimal?
                 return ((BigDecimal) wide).compareTo(new BigDecimal((BigInteger) narrow));
             }
-            
+
             // at this point we know, that 'narrow' is one of {(Atomic)Long, (Atomic)Integer, Short, Byte}
             return ((BigDecimal) wide).compareTo(BigDecimal.valueOf(narrow.longValue()));
-            
+
         }
-        
+
         // at this point we know, that wide is one of {Double, Float}
-        
+
         if(narrow instanceof Double || narrow instanceof Float) {
             return Double.compare(wide.doubleValue(), narrow.doubleValue());
         }
-        
+
         if(narrow instanceof RationalNumber) {
             //TODO[220] can we do better than that, eg. by converting BigDecimal to RationalNumber
             return BigDecimal.valueOf(wide.doubleValue())
                     .compareTo(((RationalNumber) narrow).bigDecimalValue());
         }
-        
+
         if(narrow instanceof BigInteger) {
             return BigDecimal.valueOf(wide.doubleValue())
                     .compareTo(new BigDecimal((BigInteger) narrow));
         }
-        
+
         // at this point we know, that 'narrow' is one of {(Atomic)Long, (Atomic)Integer, Short, Byte}
         return BigDecimal.valueOf(wide.doubleValue())
                 .compareTo(BigDecimal.valueOf(narrow.longValue()));
-        
+
     }
 
     // only for non-zero sign
-    private static BigInteger copySignTo(int sign, BigInteger absNumber) {
+    private static BigInteger copySignTo(final int sign, final BigInteger absNumber) {
         if(sign==-1) {
             return absNumber.negate();
-        }    
+        }
         return absNumber;
     }
-    
+
     // only for non-zero sign
-    private static BigDecimal copySignTo(int sign, BigDecimal absNumber) {
+    private static BigDecimal copySignTo(final int sign, final BigDecimal absNumber) {
         if(sign==-1) {
             return absNumber.negate();
-        }    
+        }
         return absNumber;
     }
-    
-    private static Number[] applyToArray(Number[] array, UnaryOperator<Number> operator) {
+
+    private static Number[] applyToArray(final Number[] array, final UnaryOperator<Number> operator) {
         // only ever used for length=2
         return new Number[] {
                 operator.apply(array[0]),

--- a/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
+++ b/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
@@ -160,6 +160,12 @@ public class DefaultNumberSystem implements NumberSystem {
             throw new IllegalArgumentException(msg);
         }
 
+        /**
+         * Whether given {@link Number} is ZERO.
+         * @param number - must be of type {@link #getType()}
+         * @apiNote For class internal use only, 
+         *      such that we have control over the number's type that gets past in.
+         */
         boolean isZero(Number number) {
             return zero.equals(number);
         }

--- a/src/test/java/tech/units/indriya/function/DefaultNumberSystemTest.java
+++ b/src/test/java/tech/units/indriya/function/DefaultNumberSystemTest.java
@@ -77,37 +77,37 @@ class DefaultNumberSystemTest {
 
     @ParameterizedTest
     @MethodSource("provideZeroSamples")
-    void not_one(final Number x) {
+    void notOne(final Number x) {
         assertFalse(ns.isOne(x));
     }
 
     @ParameterizedTest
     @MethodSource("provideOneSamples")
-    void not_zero(final Number x) {
+    void notZero(final Number x) {
         assertFalse(ns.isZero(x));
     }
 
     @ParameterizedTest
     @MethodSource("provideZeroSamples")
-    void less_than_one(final Number x) {
+    void lessThanOne(final Number x) {
         assertTrue(ns.isLessThanOne(x));
     }
 
     @ParameterizedTest
     @MethodSource("provideOneSamples")
-    void not_less_than_one(final Number x) {
+    void notLessThanOne(final Number x) {
         assertFalse(ns.isLessThanOne(x));
     }
 
     @ParameterizedTest
     @MethodSource("provideOneSamples")
-    void minus_one_is_less_than_one(final Number x) {
+    void minusOneIsLessThanOne(final Number x) {
         assertTrue(ns.isLessThanOne(ns.negate(x)));
     }
 
     @ParameterizedTest
     @MethodSource("provideOneSamples")
-    void one_to_max_double_comparison(final Number one) {
+    void oneToMaxDoubleComparison(final Number one) {
 
         final ComparableQuantity<Dimensionless> maxDoubleQuantity =
                 Quantities.getQuantity(Double.MAX_VALUE, AbstractUnit.ONE);
@@ -125,7 +125,7 @@ class DefaultNumberSystemTest {
 
     @ParameterizedTest
     @MethodSource("provideOneSamples")
-    void one_to_max_int_comparison(final Number one) {
+    void oneToMaxIntComparison(final Number one) {
 
         final ComparableQuantity<Dimensionless> maxIntQuantity =
                 Quantities.getQuantity(Integer.MAX_VALUE, AbstractUnit.ONE);
@@ -143,7 +143,7 @@ class DefaultNumberSystemTest {
 
     @ParameterizedTest
     @MethodSource("provideOneSamples")
-    void one_to_max_long_comparison(final Number one) {
+    void oneToMaxLongComparison(final Number one) {
 
         final ComparableQuantity<Dimensionless> maxLongQuantity =
                 Quantities.getQuantity(Long.MAX_VALUE, AbstractUnit.ONE);
@@ -161,7 +161,7 @@ class DefaultNumberSystemTest {
 
     @ParameterizedTest
     @MethodSource("provideOneSamples")
-    void one_to_large_int_comparison(final Number one) {
+    void oneToLargeIntComparison(final Number one) {
 
         final ComparableQuantity<Dimensionless> largeIntQuantity =
                 Quantities.getQuantity(
@@ -183,7 +183,7 @@ class DefaultNumberSystemTest {
 
     @ParameterizedTest
     @MethodSource("provideOneSamples")
-    void one_to_large_decimal_comparison(final Number one) {
+    void oneToLargeDecimalComparison(final Number one) {
 
         final ComparableQuantity<Dimensionless> largeDecimalQuantity =
                 Quantities.getQuantity(
@@ -203,7 +203,7 @@ class DefaultNumberSystemTest {
         assertTrue(isLargeDecimalGreaterThanOne);
     }
 
-    // -- BIGINTEGER IS-FRACTIONAL TESTS
+    // -- BIG DECIMAL IS-FRACTIONAL TESTS
 
     static Stream<BigDecimal> provideNonFractionalBigDecimalSamples() {
         return Stream.of(
@@ -211,23 +211,25 @@ class DefaultNumberSystemTest {
                 BigDecimal.valueOf(0),
                 BigDecimal.valueOf(1),
                 BigDecimal.valueOf(100, 2), // 100 * 10^-2 == 1
-                BigDecimal.valueOf(1, -2) // 1 * 10^2 == 100
+                BigDecimal.valueOf(1, -2), // 1 * 10^2 == 100
+                new BigDecimal("1234.000") // trailing zeros, should not make this decimal a non integer 
                 );
     }
     @ParameterizedTest
     @MethodSource("provideNonFractionalBigDecimalSamples")
-    void big_decimal_integer_checks(final BigDecimal decimal) {
+    void bigDecimalIntegerChecks(final BigDecimal decimal) {
         assertFalse(DefaultNumberSystem.isFractional(decimal));
     }
     @ParameterizedTest
     @MethodSource("provideNonFractionalBigDecimalSamples")
-    void big_decimal_fractional_checks(final BigDecimal decimal) {
+    void bigDecimalFractionalChecks(final BigDecimal decimal) {
         final BigDecimal fractionalPart = BigDecimal.valueOf(1, 2); // 1 * 10^-2 == 0.01
         assertTrue(DefaultNumberSystem.isFractional(decimal.add(fractionalPart)));
     }
 
     // -- BIGINTEGER IS-FRACTIONAL SPEED TESTS
 
+    /** For performance comparison, the algorithm in use till version 2.1.4 */
     static boolean isFractionalLegacy(final BigDecimal decimal) {
         try {
             decimal.toBigIntegerExact();
@@ -246,7 +248,7 @@ class DefaultNumberSystemTest {
     }
     @ParameterizedTest
     @MethodSource("namedPredicates")
-    void big_decimal_fractional_check_speed(final Predicate<BigDecimal> isFractional) {
+    void bigDecimalFractionalCheckSpeed(final Predicate<BigDecimal> isFractional) {
         // calculate some arbitrary samples
         final BigDecimal fractionalSample = new BigDecimal(
                 "3.141592653589793238462643383279502884197169399375105820974944592307816406286"

--- a/src/test/java/tech/units/indriya/function/DefaultNumberSystemTest.java
+++ b/src/test/java/tech/units/indriya/function/DefaultNumberSystemTest.java
@@ -29,6 +29,22 @@
  */
 package tech.units.indriya.function;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+import javax.measure.quantity.Dimensionless;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 
@@ -36,171 +52,236 @@ import tech.units.indriya.AbstractUnit;
 import tech.units.indriya.ComparableQuantity;
 import tech.units.indriya.quantity.Quantities;
 
-import java.math.BigDecimal;
-import java.math.BigInteger;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicLong;
-import java.util.stream.Stream;
-
-import javax.measure.quantity.Dimensionless;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.MethodSource;
-
 class DefaultNumberSystemTest {
 
     DefaultNumberSystem ns;
-    
+
     @BeforeEach
     void setUp() {
         ns = new DefaultNumberSystem();
     }
-    
+
     // -- NUMBER COMPARING TESTS
-    
+
     @ParameterizedTest
     @MethodSource("provideOneSamples")
-    void one(Number x) {
+    void one(final Number x) {
         assertTrue(ns.isOne(x));
     }
-    
+
     @ParameterizedTest
     @MethodSource("provideZeroSamples")
-    void zero(Number x) {
+    void zero(final Number x) {
         assertTrue(ns.isZero(x));
     }
-    
+
     @ParameterizedTest
     @MethodSource("provideZeroSamples")
-    void not_one(Number x) {
+    void not_one(final Number x) {
         assertFalse(ns.isOne(x));
     }
-    
+
     @ParameterizedTest
     @MethodSource("provideOneSamples")
-    void not_zero(Number x) {
+    void not_zero(final Number x) {
         assertFalse(ns.isZero(x));
     }
-    
+
     @ParameterizedTest
     @MethodSource("provideZeroSamples")
-    void less_than_one(Number x) {
+    void less_than_one(final Number x) {
         assertTrue(ns.isLessThanOne(x));
     }
-    
+
     @ParameterizedTest
     @MethodSource("provideOneSamples")
-    void not_less_than_one(Number x) {
+    void not_less_than_one(final Number x) {
         assertFalse(ns.isLessThanOne(x));
     }
-    
+
     @ParameterizedTest
     @MethodSource("provideOneSamples")
-    void minus_one_is_less_than_one(Number x) {
+    void minus_one_is_less_than_one(final Number x) {
         assertTrue(ns.isLessThanOne(ns.negate(x)));
     }
-    
+
     @ParameterizedTest
     @MethodSource("provideOneSamples")
-    void one_to_max_double_comparison(Number one) {
-        
-        final ComparableQuantity<Dimensionless> maxDoubleQuantity = 
+    void one_to_max_double_comparison(final Number one) {
+
+        final ComparableQuantity<Dimensionless> maxDoubleQuantity =
                 Quantities.getQuantity(Double.MAX_VALUE, AbstractUnit.ONE);
 
-        final boolean isOneLessThanMaxDouble = 
+        final boolean isOneLessThanMaxDouble =
                 ns.compare(one, maxDoubleQuantity.getValue()) < 0;
-        
+
         assertTrue(isOneLessThanMaxDouble);
-        
-        final boolean isMaxDoubleGreaterThanOne = 
+
+        final boolean isMaxDoubleGreaterThanOne =
                 ns.compare(maxDoubleQuantity.getValue(), one) > 0;
-        
+
         assertTrue(isMaxDoubleGreaterThanOne);
     }
-    
+
     @ParameterizedTest
     @MethodSource("provideOneSamples")
-    void one_to_max_int_comparison(Number one) {
-        
-        final ComparableQuantity<Dimensionless> maxIntQuantity = 
+    void one_to_max_int_comparison(final Number one) {
+
+        final ComparableQuantity<Dimensionless> maxIntQuantity =
                 Quantities.getQuantity(Integer.MAX_VALUE, AbstractUnit.ONE);
 
-        final boolean isOneLessThanMaxInt = 
+        final boolean isOneLessThanMaxInt =
                 ns.compare(one, maxIntQuantity.getValue()) < 0;
-        
+
         assertTrue(isOneLessThanMaxInt);
-        
-        final boolean isMaxIntGreaterThanOne = 
+
+        final boolean isMaxIntGreaterThanOne =
                 ns.compare(maxIntQuantity.getValue(), one) > 0;
-        
+
         assertTrue(isMaxIntGreaterThanOne);
     }
-    
+
     @ParameterizedTest
     @MethodSource("provideOneSamples")
-    void one_to_max_long_comparison(Number one) {
-        
-        final ComparableQuantity<Dimensionless> maxLongQuantity = 
+    void one_to_max_long_comparison(final Number one) {
+
+        final ComparableQuantity<Dimensionless> maxLongQuantity =
                 Quantities.getQuantity(Long.MAX_VALUE, AbstractUnit.ONE);
 
-        final boolean isOneLessThanMaxLong = 
+        final boolean isOneLessThanMaxLong =
                 ns.compare(one, maxLongQuantity.getValue()) < 0;
-        
+
         assertTrue(isOneLessThanMaxLong);
-        
-        final boolean isMaxLongGreaterThanOne = 
+
+        final boolean isMaxLongGreaterThanOne =
                 ns.compare(maxLongQuantity.getValue(), one) > 0;
-        
+
         assertTrue(isMaxLongGreaterThanOne);
     }
-    
+
     @ParameterizedTest
     @MethodSource("provideOneSamples")
-    void one_to_large_int_comparison(Number one) {
-        
-        final ComparableQuantity<Dimensionless> largeIntQuantity = 
+    void one_to_large_int_comparison(final Number one) {
+
+        final ComparableQuantity<Dimensionless> largeIntQuantity =
                 Quantities.getQuantity(
                         BigInteger
                             .valueOf(Long.MAX_VALUE)
-                            .add(BigInteger.valueOf(Long.MAX_VALUE)), 
+                            .add(BigInteger.valueOf(Long.MAX_VALUE)),
                         AbstractUnit.ONE);
 
-        final boolean isOneLessThanLargeInt = 
+        final boolean isOneLessThanLargeInt =
                 ns.compare(one, largeIntQuantity.getValue()) < 0;
-        
+
         assertTrue(isOneLessThanLargeInt);
-        
-        final boolean isLargeIntGreaterThanOne = 
+
+        final boolean isLargeIntGreaterThanOne =
                 ns.compare(largeIntQuantity.getValue(), one) > 0;
-        
+
         assertTrue(isLargeIntGreaterThanOne);
     }
-    
+
     @ParameterizedTest
     @MethodSource("provideOneSamples")
-    void one_to_large_decimal_comparison(Number one) {
-        
-        final ComparableQuantity<Dimensionless> largeDecimalQuantity = 
+    void one_to_large_decimal_comparison(final Number one) {
+
+        final ComparableQuantity<Dimensionless> largeDecimalQuantity =
                 Quantities.getQuantity(
                         BigDecimal
                             .valueOf(Double.MAX_VALUE)
-                            .add(BigDecimal.valueOf(Double.MAX_VALUE)), 
+                            .add(BigDecimal.valueOf(Double.MAX_VALUE)),
                         AbstractUnit.ONE);
 
-        final boolean isOneLessThanLargeDecimal = 
+        final boolean isOneLessThanLargeDecimal =
                 ns.compare(one, largeDecimalQuantity.getValue()) < 0;
-        
+
         assertTrue(isOneLessThanLargeDecimal);
-        
-        final boolean isLargeDecimalGreaterThanOne = 
+
+        final boolean isLargeDecimalGreaterThanOne =
                 ns.compare(largeDecimalQuantity.getValue(), one) > 0;
-        
+
         assertTrue(isLargeDecimalGreaterThanOne);
     }
-    
+
+    // -- BIGINTEGER IS-FRACTIONAL TESTS
+
+    static Stream<BigDecimal> provideNonFractionalBigDecimalSamples() {
+        return Stream.of(
+                BigDecimal.valueOf(-1),
+                BigDecimal.valueOf(0),
+                BigDecimal.valueOf(1),
+                BigDecimal.valueOf(100, 2), // 100 * 10^-2 == 1
+                BigDecimal.valueOf(1, -2) // 1 * 10^2 == 100
+                );
+    }
+    @ParameterizedTest
+    @MethodSource("provideNonFractionalBigDecimalSamples")
+    void big_decimal_integer_checks(final BigDecimal decimal) {
+        assertFalse(DefaultNumberSystem.isFractional(decimal));
+    }
+    @ParameterizedTest
+    @MethodSource("provideNonFractionalBigDecimalSamples")
+    void big_decimal_fractional_checks(final BigDecimal decimal) {
+        final BigDecimal fractionalPart = BigDecimal.valueOf(1, 2); // 1 * 10^-2 == 0.01
+        assertTrue(DefaultNumberSystem.isFractional(decimal.add(fractionalPart)));
+    }
+
+    // -- BIGINTEGER IS-FRACTIONAL SPEED TESTS
+
+    static boolean isFractionalLegacy(final BigDecimal decimal) {
+        try {
+            decimal.toBigIntegerExact();
+            return false;
+        } catch (ArithmeticException e) {
+            return true;
+        }
+    }
+    static Stream<Arguments> namedPredicates() {
+        return Stream.of(
+            Arguments.of(Named.of("Old Method",
+                        (Predicate<BigDecimal>)DefaultNumberSystemTest::isFractionalLegacy)),
+            Arguments.of(Named.of("New Method",
+                    (Predicate<BigDecimal>)DefaultNumberSystem::isFractional))
+        );
+    }
+    @ParameterizedTest
+    @MethodSource("namedPredicates")
+    void big_decimal_fractional_check_speed(final Predicate<BigDecimal> isFractional) {
+        // calculate some arbitrary samples
+        final BigDecimal fractionalSample = new BigDecimal(
+                "3.141592653589793238462643383279502884197169399375105820974944592307816406286"
+                + "208998628034825342117067982148086513282306647093844609550582231725359408128481"
+                + "117450284102701938521105559644622948954930381964428810975665933446128475648233"
+                + "786783165271201909145648566923460348610454326648213393607260249141273724587006"
+                + "606315588174881520920962829254091715364367892590360011330530548820466521384146"
+                + "951941511609433057270365759591953092186117381932611793105118548074462379962749"
+                + "567351885752724891227938183011949129833673362440656643086021394946395224737190"
+                + "702179860943702770539217176293176752384674818467669405132000568127145263560827",
+                MathContext.UNLIMITED);
+        final BigDecimal integerSample = fractionalSample.multiply(BigDecimal.valueOf(1, -624), MathContext.UNLIMITED);
+
+        assertTrue(isFractional.test(fractionalSample));
+        assertFalse(isFractional.test(integerSample));
+
+        final BigDecimal[] samples = new BigDecimal[] {
+                fractionalSample,
+                integerSample};
+
+        // speed test (doing some indirection to trick the JVM into not optimizing)
+        for (int i = 0; i < 300_000; i++) {
+            int index = i%2;
+            BigDecimal sample = samples[index];
+            if(index==0) {
+                assertTrue(isFractional.test(sample));
+            } else {
+                assertFalse(isFractional.test(sample));
+            }
+        }
+
+    }
+
     // -- SAMPLER
-    
+
     static Stream<Number> provideOneSamples() {
         return Stream.<Number>of(
                 (byte) 1,
@@ -216,7 +297,7 @@ class DefaultNumberSystemTest {
                 new AtomicLong(1L)
                 );
     }
-    
+
     static Stream<Number> provideZeroSamples() {
         return Stream.<Number>of(
                 (byte) 0,
@@ -232,5 +313,5 @@ class DefaultNumberSystemTest {
                 new AtomicLong(0L)
                 );
     }
-    
+
 }


### PR DESCRIPTION
Improvements:
- [x] Avoid creation of stacktraces in `boolean isInteger(NumberType numberType, Number number)`
- [x] Avoid creation of stacktraces in `Number narrow(Number number)`
- [x] Add a testcase for `BigDecimal` like 1234.000 (note the trailing zeros)
- [x] Refactor `isZero(Number)` check into `NumberType`, and provide optimized variants for `RationalNumber`, `BigInteger` and `BigDecimal`
- [x] Shortcut multiplication in `multiplyWideAndNarrow(...)` if any of the operands is zero.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/indriya/405)
<!-- Reviewable:end -->
