### PR TITLE
Change addUnit methods to protected and add one more addUnit method

### DIFF
--- a/src/main/java/tech/units/indriya/unit/Units.java
+++ b/src/main/java/tech/units/indriya/unit/Units.java
@@ -627,7 +627,7 @@ public class Units extends AbstractSystemOfUnits {
      *            the string to use as name
      * @return <code>unit</code>.
      */
-    private static <U extends Unit<?>> U addUnit(U unit, String name) {
+	protected static <U extends Unit<?>> U addUnit(U unit, String name) {
     	if (name != null && unit instanceof AbstractUnit) {
     	    return Helper.addUnit(INSTANCE.units, unit, name);
     	} else {
@@ -642,7 +642,7 @@ public class Units extends AbstractSystemOfUnits {
 	 * @param unit the unit being added.
 	 * @return <code>unit</code>.
 	 */
-	private static <U extends Unit<?>> U addUnit(U unit) {
+	protected static <U extends Unit<?>> U addUnit(U unit) {
 		INSTANCE.units.add(unit);
 		return unit;
 	}
@@ -655,7 +655,7 @@ public class Units extends AbstractSystemOfUnits {
 	 * @param type the quantity type.
 	 * @return <code>unit</code>.
 	 */
-	private static <U extends AbstractUnit<?>> U addUnit(U unit, String name, Class<? extends Quantity<?>> type) {
+	protected static <U extends AbstractUnit<?>> U addUnit(U unit, String name, Class<? extends Quantity<?>> type) {
 		Helper.addUnit(INSTANCE.units, unit, name);
 		INSTANCE.quantityToUnit.put(type, unit);
 		return unit;
@@ -668,9 +668,13 @@ public class Units extends AbstractSystemOfUnits {
 	 * @param type the quantity type.
 	 * @return <code>unit</code>.
 	 */
-	private static <U extends AbstractUnit<?>> U addUnit(U unit, Class<? extends Quantity<?>> type) {
+	protected static <U extends AbstractUnit<?>> U addUnit(U unit, Class<? extends Quantity<?>> type) {
 		INSTANCE.units.add(unit);
 		INSTANCE.quantityToUnit.put(type, unit);
 		return unit;
+	}
+
+	protected static <U extends AbstractUnit<?>> U addUnit(U transformedUnit, String name, String symbol) {
+		return AbstractSystemOfUnits.Helper.addUnit(INSTANCE.units, transformedUnit, name, symbol);
 	}
 }

--- a/src/main/java/tech/units/indriya/unit/Units.java
+++ b/src/main/java/tech/units/indriya/unit/Units.java
@@ -674,7 +674,7 @@ public class Units extends AbstractSystemOfUnits {
 		return unit;
 	}
 
-	protected static <U extends AbstractUnit<?>> U addUnit(U transformedUnit, String name, String symbol) {
-		return AbstractSystemOfUnits.Helper.addUnit(INSTANCE.units, transformedUnit, name, symbol);
+	protected static <U extends AbstractUnit<?>> U addUnit(U unit, String name, String symbol) {
+		return Helper.addUnit(INSTANCE.units, unit, name, symbol);
 	}
 }


### PR DESCRIPTION
In order for this project to be easily extendable, we can change addUnit methods to protected so that they can be accessed in client applications to add additional units to support the conversions of more unit types.

For the use cases, please see my program: https://github.com/wujiang1900/unit-converter. In particular, please refer to https://github.com/wujiang1900/unit-converter/blob/main/src/main/java/com/challenge/unitconverter/grader/javaximpl/AdditionalUnits.java and see how I'm able to add FAHRENHEIT and RANKINE and support their conversions with the existing CELSIUS unit. 

I had to make the changes in this PR and built a new snapshot of indriya to be used in my application to make the above additional unit support working. Therefore please review my PR at your earliest conversion. The code changes below are tiny, but the impact to make indriya flexible and extendable is huge.

Thank you for reviewing!

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/indriya/418)
<!-- Reviewable:end -->
