### PR TITLE
Add missing `return` keyword.

### DIFF
--- a/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
+++ b/src/main/java/tech/units/indriya/function/DefaultNumberSystem.java
@@ -352,7 +352,7 @@ public class DefaultNumberSystem implements NumberSystem {
             return Math.abs(intValue);
         }
         if(number instanceof Short || number instanceof Byte) {
-            Math.abs(number.intValue()); // widen to int
+            return Math.abs(number.intValue()); // widen to int
         }
         throw unsupportedNumberType(number);
     }


### PR DESCRIPTION
This was discovered by Error Prone's
[`CheckReturnValue`](https://errorprone.info/bugpattern/CheckReturnValue) analysis.