### PR TITLE
use unicode superscript instead of Square M Squared and Square M Cubed

### DIFF
--- a/src/main/java/tech/units/indriya/format/SimpleUnitFormat.java
+++ b/src/main/java/tech/units/indriya/format/SimpleUnitFormat.java
@@ -461,9 +461,9 @@ public abstract class SimpleUnitFormat extends AbstractUnitFormat {
             alias(Units.MONTH, "mon");
             alias(Units.MONTH, "month");
             label(Units.KILOMETRE_PER_HOUR, "km/h");
-            labelWithPrefixes(Units.SQUARE_METRE, "\u33A1");
+            labelWithPrefixes(Units.SQUARE_METRE, "m\u00B2");
             aliasWithPrefixes(Units.SQUARE_METRE, "m2");
-            labelWithPrefixes(Units.CUBIC_METRE, "\u33A5");
+            labelWithPrefixes(Units.CUBIC_METRE, "m\u00B3");
             aliasWithPrefixes(Units.CUBIC_METRE, "m3");
             labelWithPrefixes(Units.LITRE, "l");
 


### PR DESCRIPTION
`u33A1` looks like this: `㎡`
`m\u00B2` looks like this: `m²`

per wikipedia the latter is preffered: https://en.wikipedia.org/wiki/Square_metre

Same for cubic: `㎥` vs `m³`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/unitsofmeasurement/indriya/437)
<!-- Reviewable:end -->
